### PR TITLE
fixing-bug-caused-by-flow-cache

### DIFF
--- a/app/src/main/java/com/ivy/wallet/ui/RootActivity.kt
+++ b/app/src/main/java/com/ivy/wallet/ui/RootActivity.kt
@@ -117,10 +117,6 @@ class RootActivity : AppCompatActivity(), RootScreen {
             }
         }
 
-        // Check if the intent was triggered by a shortcut action, and notify the view model of the shortcut click event
-        if (intent.action == SHORTCUT_ACTION) {
-            viewModel.onEvent(RootEvent.ShortcutClick(intent))
-        }
 
         // Make the app drawing area fullscreen (draw behind status and nav bars)
         WindowCompat.setDecorFitsSystemWindows(window, false)
@@ -179,6 +175,10 @@ class RootActivity : AppCompatActivity(), RootScreen {
                 test = { TestScreen() }
             )
         )
+        // Check if the intent was triggered by a shortcut action, and notify the view model of the shortcut click event
+        if (intent.action == SHORTCUT_ACTION) {
+            viewModel.onEvent(RootEvent.ShortcutClick(intent))
+        }
     }
 
     override fun onWindowFocusChanged(hasFocus: Boolean) {
@@ -203,11 +203,6 @@ class RootActivity : AppCompatActivity(), RootScreen {
         super.onPause()
 //        if (viewModel.isAppLockEnabled())
 //            viewModel.startUserInactiveTimeCounter()
-    }
-    //resetting the replay cache of shared flow to avoid replaying unwanted navigation actions
-    override fun onDestroy() {
-        navigator.resetReplayCache()
-        super.onDestroy()
     }
 
     private fun authenticateWithOSBiometricsModal(

--- a/app/src/main/java/com/ivy/wallet/ui/RootActivity.kt
+++ b/app/src/main/java/com/ivy/wallet/ui/RootActivity.kt
@@ -204,6 +204,11 @@ class RootActivity : AppCompatActivity(), RootScreen {
 //        if (viewModel.isAppLockEnabled())
 //            viewModel.startUserInactiveTimeCounter()
     }
+    //resetting the replay cache of shared flow to avoid replaying unwanted navigation actions
+    override fun onDestroy() {
+        navigator.resetReplayCache()
+        super.onDestroy()
+    }
 
     private fun authenticateWithOSBiometricsModal(
         biometricPromptCallback: BiometricPrompt.AuthenticationCallback

--- a/navigation/src/main/java/com/ivy/navigation/Navigator.kt
+++ b/navigation/src/main/java/com/ivy/navigation/Navigator.kt
@@ -2,6 +2,7 @@ package com.ivy.navigation
 
 import androidx.compose.runtime.Stable
 import androidx.navigation.NavOptionsBuilder
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import javax.inject.Inject
@@ -24,6 +25,11 @@ class Navigator @Inject constructor() {
 
     fun back() {
         _actions.tryEmit(Action.Back)
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun resetReplayCache(){
+        _actions.resetReplayCache()
     }
 
     internal sealed class Action {

--- a/navigation/src/main/java/com/ivy/navigation/Navigator.kt
+++ b/navigation/src/main/java/com/ivy/navigation/Navigator.kt
@@ -2,7 +2,6 @@ package com.ivy.navigation
 
 import androidx.compose.runtime.Stable
 import androidx.navigation.NavOptionsBuilder
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import javax.inject.Inject
@@ -12,7 +11,7 @@ import javax.inject.Singleton
 @Singleton
 class Navigator @Inject constructor() {
     private val _actions = MutableSharedFlow<Action>(
-        replay = 1,
+        replay = 0,
         extraBufferCapacity = 10
     )
     internal val actions: Flow<Action> = _actions
@@ -25,11 +24,6 @@ class Navigator @Inject constructor() {
 
     fun back() {
         _actions.tryEmit(Action.Back)
-    }
-
-    @OptIn(ExperimentalCoroutinesApi::class)
-    fun resetReplayCache(){
-        _actions.resetReplayCache()
     }
 
     internal sealed class Action {


### PR DESCRIPTION
## Pull Request (PR) Checklist
Please check if your pull request fulfills the following requirements:
- [x] The PR is submitted to the `develop` branch.
- [x] I've read the **[Contribution Guidelines](https://github.com/Ivy-Apps/ivy-wallet/blob/main/CONTRIBUTING.md)**.
- [x] The code builds and is tested on a real Android device.
- [x] I confirm that I've run the code locally and everything works as expected.


## Pull Request Type
Please check the type of change your PR introduces:

- [x] Bugfix


## Does this PR closes any GitHub Issues?
Check **[Ivy Wallet Issues](https://github.com/Ivy-Apps/ivy-wallet/issues)**.
- Closes #N/A 

## Bug
- Navigate to more menu screen(any screen) from home screen and pressing back ,and pressing back again from home screen ,and then launching the app again will take the user to more menu screen
- Add an income or expense or transfer ,press back ,and then launch the app again ,the app crashes

## Reason
The replay = 1 set at the navigators shared flow to make sure shortcut action invoked is not lost.
When back is pressed from home screen ,the app's process is not killed ,so the navigators _actions shared flow still exists and when launching the app again and navigation root subscribes to it ,it gets the last invoked action (popBackStack() or navigate()) which is unwanted.

## Fix
Resetting the replay cache when back is pressed..
works as expected :)
