### PR TITLE
Fix Gradle Wrapper Uprade (again)

### DIFF
--- a/.github/workflows/upgrade-gradle-wrapper.yml
+++ b/.github/workflows/upgrade-gradle-wrapper.yml
@@ -9,7 +9,7 @@ jobs:
   upgrade-gradle-wrapper:
     runs-on: ubuntu-latest
     env:
-      WRAPPER_UPGRADE_GIT_TOKEN: ${{ secrets.IVYWALLET_BOT_GITHUB_PAT }}
+      WRAPPER_UPGRADE_GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Lets go with this for now 🤓 
I will not run tests, but you get at least informed about it via PRs.
A simple `checkout PR_number` and `./gradlew check` or something should reveal if it works or not 😉 

Better than nothing I would say.
Your token can also be updated later, in case this apporoach is getting too annoying. But I doubt it, because Gradle reelase are also not *that often* 🙃 
