### PR TITLE
Fix negative zero issue on balance

### DIFF
--- a/temp-legacy-code/src/main/java/com/ivy/legacy/legacy/ui/theme/components/BalanceRow.kt
+++ b/temp-legacy-code/src/main/java/com/ivy/legacy/legacy/ui/theme/components/BalanceRow.kt
@@ -19,9 +19,9 @@ import com.ivy.design.l0_system.UI
 import com.ivy.design.l0_system.style
 import com.ivy.legacy.IvyWalletComponentPreview
 import com.ivy.legacy.utils.decimalPartFormatted
+import com.ivy.legacy.utils.integerPartFormatted
 import com.ivy.legacy.utils.shortenAmount
 import com.ivy.legacy.utils.shouldShortAmount
-import java.text.DecimalFormat
 
 @Deprecated("Old design system. Use `:ivy-design` and Material3")
 @Composable
@@ -121,12 +121,10 @@ fun BalanceRow(
             Spacer(Modifier.width(spacerCurrency))
         }
 
-        val balancePrecise = balance.toBigDecimal()
-
         val integerPartFormatted = if (shortAmount) {
             shortenAmount(balance)
         } else {
-            DecimalFormat("###,###").format(balancePrecise.toInt())
+            integerPartFormatted(balance)
         }
         Text(
             text = when {

--- a/temp-legacy-code/src/main/java/com/ivy/legacy/utils/AmountFormatting.kt
+++ b/temp-legacy-code/src/main/java/com/ivy/legacy/utils/AmountFormatting.kt
@@ -194,3 +194,17 @@ fun formatInputAmount(
 
     return null
 }
+
+/**
+ toInt on numbers in the range (-1.0, 0.0) (exclusive of boundaries) will produce a positive int 0
+ So, this function append negative sign in that case
+ */
+fun integerPartFormatted(value: Double): String {
+    val preciseValue = value.toBigDecimal()
+    val formattedValue = DecimalFormat("###,###").format(preciseValue.toInt())
+    return if (value > -1.0 && value < 0.0) {
+        "-$formattedValue"
+    } else {
+        formattedValue
+    }
+}


### PR DESCRIPTION
## Pull Request (PR) Checklist
Please check if your pull request fulfills the following requirements:
- [x] The PR is submitted to the `main` branch.
- [x] I've read the [Contribution Guidelines](https://github.com/Ivy-Apps/ivy-wallet/blob/main/CONTRIBUTING.md).
- [x] I've read the [Architecture Guidelines](https://github.com/Ivy-Apps/ivy-wallet/blob/main/docs/Architecture.md).
- [x] My code builds and is tested on a real Android device.
- [x] I confirm that I've run the code locally and everything works as expected.

## What's changed?
Obtaining the integer part of balance via `toInt()` method drops the negative sign when the balance x is such that  -1.0 < x < 0.0. For example, (-0.21).toInt() will produce 0.
This PR will append a negative sign to the integer part of the balance in this case.

### Before Fix

https://github.com/Ivy-Apps/ivy-wallet/assets/12750237/96e52e8c-fab3-4201-b2b7-3f3409b1e5ab


### After Fix
https://github.com/Ivy-Apps/ivy-wallet/assets/12750237/80fe36d7-34e3-4c94-abdd-8e739b3bf495

## Does this PR closes any GitHub Issues?
- Closes [2518](https://github.com/Ivy-Apps/ivy-wallet/issues/2518)