### PR TITLE
Change Balance Row to use a single Text

### DIFF
--- a/screen-accounts/src/main/java/com/ivy/accounts/AccountsTab.kt
+++ b/screen-accounts/src/main/java/com/ivy/accounts/AccountsTab.kt
@@ -287,14 +287,13 @@ private fun AccountHeader(
                 .clickableNoIndication {
                     onBalanceClick()
                 },
-            decimalPaddingTop = 7.dp,
-            spacerDecimal = 6.dp,
+
             textColor = contrastColor,
             currency = currency,
             balance = accountData.balance,
 
             integerFontSize = 30.sp,
-            decimalFontSize = 18.sp,
+
             currencyFontSize = 30.sp,
 
             currencyUpfront = false

--- a/screen-balance/src/main/java/com/ivy/balance/BalanceScreen.kt
+++ b/screen-balance/src/main/java/com/ivy/balance/BalanceScreen.kt
@@ -208,7 +208,6 @@ private fun ColumnScope.BalanceAfterPlannedPayments(
             balance = balanceAfterPlannedPayments,
 
             integerFontSize = 30.sp,
-            decimalFontSize = 18.sp,
             currencyFontSize = 18.sp,
 
             currencyUpfront = false

--- a/screen-categories/src/main/java/com/ivy/categories/CategoriesScreen.kt
+++ b/screen-categories/src/main/java/com/ivy/categories/CategoriesScreen.kt
@@ -397,15 +397,12 @@ private fun CategoryHeader(
         BalanceRow(
             modifier = Modifier.align(Alignment.CenterHorizontally),
 
-            decimalPaddingTop = 4.dp,
             textColor = contrastColor,
             currency = currency,
             balance = categoryData.monthlyBalance,
 
             integerFontSize = 30.sp,
-            decimalFontSize = 18.sp,
             currencyFontSize = 30.sp,
-
             currencyUpfront = false,
             balanceAmountPrefix = com.ivy.legacy.utils.balancePrefix(
                 income = categoryData.monthlyIncome,

--- a/screen-loans/src/main/java/com/ivy/loans/loan/LoansScreen.kt
+++ b/screen-loans/src/main/java/com/ivy/loans/loan/LoansScreen.kt
@@ -316,14 +316,12 @@ private fun LoanHeader(
         BalanceRow(
             modifier = Modifier
                 .align(Alignment.CenterHorizontally),
-            decimalPaddingTop = 7.dp,
-            spacerDecimal = 6.dp,
+
             textColor = contrastColor,
             currency = displayLoan.currencyCode ?: getDefaultFIATCurrency().currencyCode,
             balance = leftToPay,
 
             integerFontSize = 30.sp,
-            decimalFontSize = 18.sp,
             currencyFontSize = 30.sp,
 
             currencyUpfront = false

--- a/temp-legacy-code/src/main/java/com/ivy/legacy/legacy/ui/theme/components/BalanceRow.kt
+++ b/temp-legacy-code/src/main/java/com/ivy/legacy/legacy/ui/theme/components/BalanceRow.kt
@@ -19,6 +19,7 @@ import com.ivy.design.l0_system.UI
 import com.ivy.design.l0_system.style
 import com.ivy.legacy.IvyWalletComponentPreview
 import com.ivy.legacy.utils.decimalPartFormatted
+import com.ivy.legacy.utils.format
 import com.ivy.legacy.utils.integerPartFormatted
 import com.ivy.legacy.utils.shortenAmount
 import com.ivy.legacy.utils.shouldShortAmount
@@ -37,18 +38,13 @@ fun BalanceRowMedium(
 ) {
     BalanceRow(
         modifier = modifier,
-
-        decimalPaddingTop = 8.dp,
         textColor = textColor,
         currency = currency,
         balance = balance,
         hiddenMode = hiddenMode,
         spacerCurrency = 12.dp,
-        spacerDecimal = 8.dp,
         currencyFontSize = 24.sp,
         integerFontSize = 26.sp,
-        decimalFontSize = 11.sp,
-
         balanceAmountPrefix = balanceAmountPrefix,
         currencyUpfront = currencyUpfront,
         shortenBigNumbers = shortenBigNumbers
@@ -68,18 +64,13 @@ fun BalanceRowMini(
 ) {
     BalanceRow(
         modifier = modifier,
-
-        decimalPaddingTop = 6.dp,
         textColor = textColor,
         currency = currency,
         balance = balance,
         hiddenMode = hiddenMode,
         spacerCurrency = 8.dp,
-        spacerDecimal = 4.dp,
         currencyFontSize = 20.sp,
         integerFontSize = 22.sp,
-        decimalFontSize = 7.sp,
-
         balanceAmountPrefix = balanceAmountPrefix,
         currencyUpfront = currencyUpfront,
         shortenBigNumbers = shortenBigNumbers
@@ -94,12 +85,9 @@ fun BalanceRow(
     hiddenMode: Boolean = false,
 
     textColor: Color = UI.colors.pureInverse,
-    decimalPaddingTop: Dp = 12.dp,
     spacerCurrency: Dp = 12.dp,
-    spacerDecimal: Dp = 8.dp,
     currencyFontSize: TextUnit? = null,
     integerFontSize: TextUnit? = null,
-    decimalFontSize: TextUnit? = null,
 
     currencyUpfront: Boolean = true,
     balanceAmountPrefix: String? = null,
@@ -124,7 +112,7 @@ fun BalanceRow(
         val integerPartFormatted = if (shortAmount) {
             shortenAmount(balance)
         } else {
-            integerPartFormatted(balance)
+            balance.format(currency)
         }
         Text(
             text = when {
@@ -144,28 +132,6 @@ fun BalanceRow(
                 ).copy(fontSize = integerFontSize)
             }
         )
-
-        if (!shortAmount) {
-            Spacer(Modifier.width(spacerDecimal))
-
-            Text(
-                modifier = Modifier
-                    .align(Alignment.Top)
-                    .padding(top = decimalPaddingTop),
-                text = if (hiddenMode) "" else decimalPartFormatted(currency, balance),
-                style = if (decimalFontSize == null) {
-                    UI.typo.nB1.style(
-                        fontWeight = FontWeight.Bold,
-                        color = textColor
-                    )
-                } else {
-                    UI.typo.nB1.style(
-                        fontWeight = FontWeight.Bold,
-                        color = textColor
-                    ).copy(fontSize = decimalFontSize)
-                }
-            )
-        }
 
         if (!currencyUpfront) {
             Spacer(Modifier.width(spacerCurrency))
@@ -208,8 +174,9 @@ private fun Preview_Default() {
         BalanceRow(
             textColor = UI.colors.pureInverse,
             currency = "BGN",
-            balance = 3520.60,
-            balanceAmountPrefix = null
+            balance = 3520000.60,
+            balanceAmountPrefix = null,
+            shortenBigNumbers = true
         )
     }
 }

--- a/temp-legacy-code/src/main/java/com/ivy/legacy/legacy/ui/theme/modal/IvyModalDomainComponents.kt
+++ b/temp-legacy-code/src/main/java/com/ivy/legacy/legacy/ui/theme/modal/IvyModalDomainComponents.kt
@@ -59,13 +59,9 @@ fun ModalAmountSection(
                 .testTag("amount_balance"),
             currency = currency,
             balance = amount,
-
-            decimalPaddingTop = 8.dp,
-            spacerDecimal = 4.dp,
             spacerCurrency = 8.dp,
 
             integerFontSize = 40.sp,
-            decimalFontSize = 18.sp,
             currencyFontSize = 30.sp,
 
             currencyUpfront = false

--- a/temp-legacy-code/src/main/java/com/ivy/legacy/ui/component/edit/core/EditBottomSheet.kt
+++ b/temp-legacy-code/src/main/java/com/ivy/legacy/ui/component/edit/core/EditBottomSheet.kt
@@ -693,12 +693,10 @@ private fun Amount(
                 currency = currency,
                 balance = amount,
 
-                decimalPaddingTop = currencyPaddingTop.dp,
-                spacerDecimal = spacerInteger.dp,
+
                 spacerCurrency = 8.dp,
 
                 integerFontSize = integerFontSize.sp,
-                decimalFontSize = 18.sp,
                 currencyFontSize = currencyFontSize.sp,
 
                 currencyUpfront = false


### PR DESCRIPTION
## Pull Request (PR) Checklist
Please check if your pull request fulfills the following requirements:
- [x] The PR is submitted to the `main` branch.
- [x] I've read the [Contribution Guidelines](https://github.com/Ivy-Apps/ivy-wallet/blob/main/CONTRIBUTING.md).
- [x] I've read the [Architecture Guidelines](https://github.com/Ivy-Apps/ivy-wallet/blob/main/docs/Architecture.md).
- [x] My code builds and is tested on a real Android device.
- [x] I confirm that I've run the code locally and everything works as expected.


## What's Changed:
-  Changed the BalanceRow Composable to use a single Text for displaying the balance instead of two separate ones for integer and decimal part.
-  Thus making both the integer and decimal parts look uniform in style.


## Risk Factors

**What may go wrong if we merge your PR?**

-  This is only a UI change so hopefully nothing :)

## Does this PR closes any GitHub Issues?

Check **[Ivy Wallet Issues](https://github.com/Ivy-Apps/ivy-wallet/issues/2712)**.

- Closes #2712
