### PR TITLE
arabic number pad fix ,shifted from native numbers to standard US num…

### DIFF
--- a/temp-legacy-code/src/main/java/com/ivy/legacy/utils/AmountFormatting.kt
+++ b/temp-legacy-code/src/main/java/com/ivy/legacy/utils/AmountFormatting.kt
@@ -3,6 +3,7 @@ package com.ivy.legacy.utils
 import com.ivy.wallet.domain.data.IvyCurrency
 import java.text.DecimalFormat
 import java.text.DecimalFormatSymbols
+import java.util.Locale
 import kotlin.math.abs
 import kotlin.math.log10
 import kotlin.math.truncate
@@ -131,7 +132,7 @@ fun shouldShortAmount(amount: Double): Boolean {
 }
 
 fun formatInt(number: Int): String {
-    return DecimalFormat("#,###,###,###").format(number)
+    return DecimalFormat("#,###,###,###", DecimalFormatSymbols(Locale.US)).format(number)
 }
 
 fun decimalPartFormatted(currency: String, value: Double): String {
@@ -196,8 +197,8 @@ fun formatInputAmount(
 }
 
 /**
- toInt on numbers in the range (-1.0, 0.0) (exclusive of boundaries) will produce a positive int 0
- So, this function append negative sign in that case
+toInt on numbers in the range (-1.0, 0.0) (exclusive of boundaries) will produce a positive int 0
+So, this function append negative sign in that case
  */
 fun integerPartFormatted(value: Double): String {
     val preciseValue = value.toBigDecimal()


### PR DESCRIPTION
…ber system

## Pull Request (PR) Checklist
Please check if your pull request fulfills the following requirements:
- [x] The PR is submitted to the `main` branch.
- [x]I've read the [Contribution Guidelines](https://github.com/Ivy-Apps/ivy-wallet/blob/main/CONTRIBUTING.md) and my PR doesn't break the "Contributing Rules".
- [x]  I've read the [Architecture Guidelines](https://github.com/Ivy-Apps/ivy-wallet/blob/main/docs/Architecture.md).
- [x] I confirm that I've run the code locally and everything works as expected.
- [x] 🎬 I've attached a **screen recoding** of the changes. 
[bug_fix.webm](https://github.com/Ivy-Apps/ivy-wallet/assets/13647384/8e778f79-4192-47f6-8ce3-f25d317410da)


> Tip: drag & drop the video to the PR description.

## What's changed?
<!--
Tip: you can attach screenshots using a markdown table.

Before | After
---|---
image1 | image2
-->

Describe with a few bullets **what's new:**
- Might effect other areas where Locale is used to format integers.


> 💡 Tip: Please, attach screenshots and screen recordings. It helps a lot!

## Risk Factors
**What may go wrong if we merge your PR?**
-  Might effect other areas where Locale is used to format intergers.

**In what cases your code won't work?**
- I have tested most use cases it worked. 

This may be a future issue! I'm not sure if Ivy Wallet will use numbers for these strings. It uses native right-to-left language numbers
<img src="https://github.com/Ivy-Apps/ivy-wallet/assets/13647384/229a2f5b-70e8-4a4d-99f7-31729baff3f5" width="200" height="400">




## Does this PR closes any GitHub Issues?

Check **[Ivy Wallet Issues](https://github.com/Ivy-Apps/ivy-wallet/issues)**.

- Closes #1104


> Replace `ISSUE_NUMBER` with your issue number (for example Closes #1234). If you've done that correctly, you'll see the issue title linked when previewing your PR description.

## Troubleshooting CI failures

If you see any of the PR checks failing (❌) go to [Actions](https://github.com/Ivy-Apps/ivy-wallet/actions) and find it there. Or simply click "Details" next to the failed check and explore the logs to see why it has failed.

### Detekt
[Detekt](https://detekt.dev/) is a static code analyzer for Kotlin that we use to enforce code readibility and good practices.

**To run Detekt locally:**
```
./gradlew detekt
```

If the Detekt errors are caused by a legacy code, you can suppress them using a basline.

**Detekt baseline** (not recommended)
```
./scripts/detektBaseline.sh
```

### Lint

We use the [standard Android Lint](https://developer.android.com/studio/write/lint) plus [Slack's compose-lints](https://slackhq.github.io/compose-lints/) as an addition to enforce proper Compose usage.

**To run Lint locally:**
```
./scripts/lint.sh
```

If the Lint errors are caused by a legacy code, you can suppress them using a basline.

**Lint baseline** (not recommended)
```
./scripts/lintBaseline.sh
```

### Unit tests

If this job is failing this means that your changes break an existing unit test. You must identify the failing tests and fix your code.

**To run the Unit tests locally:**
```
./gradlew testDebugUnitTest
```