### PR TITLE
refs #2855 - Edit category name from add planned payment screen 

### DIFF
--- a/screen-planned-payments/src/main/java/com/ivy/planned/edit/EditPlannedScreen.kt
+++ b/screen-planned-payments/src/main/java/com/ivy/planned/edit/EditPlannedScreen.kt
@@ -316,7 +316,9 @@ private fun BoxWithConstraintsScope.UI(
     CategoryModal(
         modal = state.categoryModalData,
         onCreateCategory = { onEvent(EditPlannedScreenEvent.OnCreateCategory(it)) },
-        onEditCategory = { },
+        onEditCategory = {
+            onEvent(EditPlannedScreenEvent.OnEditCategory(it))
+        },
         dismiss = {
             onEvent(EditPlannedScreenEvent.OnCategoryModalDataChanged(null))
         }

--- a/screen-planned-payments/src/main/java/com/ivy/planned/edit/EditPlannedScreenEvent.kt
+++ b/screen-planned-payments/src/main/java/com/ivy/planned/edit/EditPlannedScreenEvent.kt
@@ -29,6 +29,7 @@ sealed interface EditPlannedScreenEvent {
 
     data class OnSave(val closeScreen: Boolean = true) : EditPlannedScreenEvent
     data object OnDelete : EditPlannedScreenEvent
+    data class OnEditCategory(val updatedCategory: Category) : EditPlannedScreenEvent
     data class OnCreateCategory(val data: CreateCategoryData) : EditPlannedScreenEvent
     data class OnCreateAccount(val data: CreateAccountData) : EditPlannedScreenEvent
     data class OnCategoryModalVisible(val visible: Boolean) : EditPlannedScreenEvent

--- a/screen-planned-payments/src/main/java/com/ivy/planned/edit/EditPlannedViewModel.kt
+++ b/screen-planned-payments/src/main/java/com/ivy/planned/edit/EditPlannedViewModel.kt
@@ -230,6 +230,7 @@ class EditPlannedViewModel @Inject constructor(
             is EditPlannedScreenEvent.OnRuleChanged ->
                 updateRule(event.startDate, event.oneTime, event.intervalN, event.intervalType)
             is EditPlannedScreenEvent.OnCategoryChanged -> updateCategory(event.newCategory)
+            is EditPlannedScreenEvent.OnEditCategory -> editCategory(event.updatedCategory)
             is EditPlannedScreenEvent.OnCategoryModalVisible ->
                 categoryModalVisible.value = event.visible
             is EditPlannedScreenEvent.OnCategoryModalDataChanged ->
@@ -472,6 +473,14 @@ class EditPlannedViewModel @Inject constructor(
                 categories.value = categoriesAct(Unit)
 
                 updateCategory(it)
+            }
+        }
+    }
+
+    private fun editCategory(updatedCategory: Category) {
+        viewModelScope.launch {
+            categoryCreator.editCategory(updatedCategory) {
+                categories.value = categoriesAct(Unit)
             }
         }
     }


### PR DESCRIPTION
## Pull Request (PR) Checklist
Please check if your pull request fulfills the following requirements:
- [x] The PR is submitted to the `main` branch.
- [x] I've read the [Contribution Guidelines](https://github.com/Ivy-Apps/ivy-wallet/blob/main/CONTRIBUTING.md) and my PR doesn't break the "Contributing Rules".
- [x] I've read the [Architecture Guidelines](https://github.com/Ivy-Apps/ivy-wallet/blob/main/docs/Architecture.md).
- [x] I confirm that I've run the code locally and everything works as expected.
- [x] 🎬 I've attached a **screen recoding** of the changes. 

## What's changed?
<!--
Tip: you can attach screenshots using a markdown table.

Before | After
---|---
image1 | image2
-->

Describe with a few bullets **what's new:**
- Fixed: On edit of category name from add planned payment screen, the name will be changed.

https://github.com/Ivy-Apps/ivy-wallet/assets/53510640/bf64436c-4b65-4bd6-95c1-68bb94314b9d


## Risk Factors

**What may go wrong if we merge your PR?**

**In what cases your code won't work?**

## Does this PR closes any GitHub Issues?

Check **[Ivy Wallet Issues](https://github.com/Ivy-Apps/ivy-wallet/issues)**.

- Closes #2855 

## Troubleshooting CI failures

If you see any of the PR checks failing (❌) go to [Actions](https://github.com/Ivy-Apps/ivy-wallet/actions) and find it there. Or simply click "Details" next to the failed check and explore the logs to see why it has failed.

### Detekt
[Detekt](https://detekt.dev/) is a static code analyzer for Kotlin that we use to enforce code readibility and good practices.

**To run Detekt locally:**
```
./gradlew detekt
```

If the Detekt errors are caused by a legacy code, you can suppress them using a basline.

**Detekt baseline** (not recommended)
```
./scripts/detektBaseline.sh
```

### Lint

We use the [standard Android Lint](https://developer.android.com/studio/write/lint) plus [Slack's compose-lints](https://slackhq.github.io/compose-lints/) as an addition to enforce proper Compose usage.

**To run Lint locally:**
```
./scripts/lint.sh
```

If the Lint errors are caused by a legacy code, you can suppress them using a basline.

**Lint baseline** (not recommended)
```
./scripts/lintBaseline.sh
```

### Unit tests

If this job is failing this means that your changes break an existing unit test. You must identify the failing tests and fix your code.

**To run the Unit tests locally:**
```
./gradlew testDebugUnitTest
```