### PR TITLE
Fixed: Tapping on "Expense title" textbox does not request focus

### DIFF
--- a/temp-legacy-code/src/main/java/com/ivy/legacy/legacy/ui/theme/components/IvyTitleTextField.kt
+++ b/temp-legacy-code/src/main/java/com/ivy/legacy/legacy/ui/theme/components/IvyTitleTextField.kt
@@ -74,6 +74,7 @@ fun ColumnScope.IvyTitleTextField(
         val view = LocalView.current
         BasicTextField(
             modifier = Modifier
+                .fillMaxWidth()
                 .testTag("input_field"),
             value = value,
             onValueChange = onValueChanged,


### PR DESCRIPTION
## Pull Request (PR) Checklist
Please check if your pull request fulfills the following requirements:
- [x] The PR is submitted to the `main` branch.
- [x] I've read the [Contribution Guidelines](https://github.com/Ivy-Apps/ivy-wallet/blob/main/CONTRIBUTING.md) and my PR doesn't break the "Contributing Rules".
- [x] I've read the [Architecture Guidelines](https://github.com/Ivy-Apps/ivy-wallet/blob/main/docs/Architecture.md).
- [x] I confirm that I've run the code locally and everything works as expected.
- [x] 🎬 I've attached a **screen recoding** of the changes. 

[Screen_recording_20240119_162547.webm](https://github.com/Ivy-Apps/ivy-wallet/assets/76241334/7f6a134f-dd6b-437e-a2e3-b7ee3037bc41)

## What's changed?

- Tapping on the empty space adjacent to "Expense title" now bring the text box to focus

Closes #2877 
