### PR TITLE
fix(HomeViewModel): get current settings to store new buffer value

### DIFF
--- a/screen/home/src/main/java/com/ivy/home/HomeViewModel.kt
+++ b/screen/home/src/main/java/com/ivy/home/HomeViewModel.kt
@@ -227,7 +227,7 @@ class HomeViewModel @Inject constructor(
                 HomeEvent.SelectPreviousMonth -> onSelectPreviousMonth()
                 is HomeEvent.SetUpcomingExpanded -> setUpcomingExpanded(event.expanded)
                 is HomeEvent.SetOverdueExpanded -> setOverdueExpanded(event.expanded)
-                is HomeEvent.SetBuffer -> setBuffer(event.buffer).fixUnit()
+                is HomeEvent.SetBuffer -> setBuffer(event.buffer)
                 is HomeEvent.SetCurrency -> setCurrency(event.currency).fixUnit()
                 HomeEvent.SwitchTheme -> switchTheme()
                 is HomeEvent.DismissCustomerJourneyCard -> dismissCustomerJourneyCard(event.card)
@@ -418,12 +418,12 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    private suspend fun setBuffer(newBuffer: Double) = settingsAct then {
-        it.copy(
-            bufferAmount = newBuffer.toBigDecimal()
-        )
-    } then updateSettingsAct then {
-        reload()
+    private fun setBuffer(newBuffer: Double) {
+        viewModelScope.launch {
+            val currentSettings = settingsAct.getSettings().copy(bufferAmount = newBuffer.toBigDecimal())
+            updateSettingsAct(currentSettings)
+            buffer.value = buffer.value.copy(amount = currentSettings.bufferAmount)
+        }
     }
 
     private suspend fun setCurrency(newCurrency: String) = settingsAct then {

--- a/temp/legacy-code/src/main/java/com/ivy/legacy/domain/action/settings/SettingsAct.kt
+++ b/temp/legacy-code/src/main/java/com/ivy/legacy/domain/action/settings/SettingsAct.kt
@@ -6,6 +6,7 @@ import com.ivy.frp.action.FPAction
 import com.ivy.frp.then
 import com.ivy.legacy.datamodel.Settings
 import com.ivy.legacy.datamodel.temp.toDomain
+import java.math.BigDecimal
 import javax.inject.Inject
 
 class SettingsAct @Inject constructor(
@@ -24,4 +25,6 @@ class SettingsAct @Inject constructor(
         }
         return currentSettings.copy(theme = newTheme)
     }
+
+    suspend fun getSettings(): Settings = this(Unit)
 }


### PR DESCRIPTION
Fix #2941
- get current settings in a coroutine to store a copy with the new buffer value
- update value on screen with buffer from stored settings

## Pull Request (PR) Checklist
Please check if your pull request fulfills the following requirements:
- [ x ] The PR is submitted to the `main` branch.
- [ x ] I've read the [Contribution Guidelines](https://github.com/Ivy-Apps/ivy-wallet/blob/main/CONTRIBUTING.md) and my PR doesn't break the rules.
- [ x ] I've read the [Architecture Guidelines](https://github.com/Ivy-Apps/ivy-wallet/blob/main/docs/Architecture.md).
- [ x ] I confirm that I've run the code locally and everything works as expected.
- [ x ] 🎬 I've attached a **screen recording** of the changes. 


https://github.com/Ivy-Apps/ivy-wallet/assets/37549606/dc80aa9b-4b86-4468-bd58-ae05b57d15e6


## What's changed?
- Now there is a coroutine to get current settings
- The screen updates this value on savings goal changed

## Risk Factors
- Settings model is highlighted as deprecated, it may require a complete migration.
- If settings are moved to new Settings model and view model it may stop working, this fix is still using deprecated annotation.

## Does this PR closes any GitHub Issues?
- Closes #2941 