### PR TITLE
Restore ISO 8601 date formatting for exported files

### DIFF
--- a/screen/reports/src/main/java/com/ivy/reports/ReportViewModel.kt
+++ b/screen/reports/src/main/java/com/ivy/reports/ReportViewModel.kt
@@ -32,7 +32,7 @@ import com.ivy.domain.RootScreen
 import com.ivy.frp.filterSuspend
 import com.ivy.legacy.IvyWalletCtx
 import com.ivy.legacy.datamodel.Account
-import com.ivy.legacy.utils.formatNicelyWithTime
+import com.ivy.legacy.utils.getISOFormattedDateTime
 import com.ivy.legacy.utils.scopedIOThread
 import com.ivy.legacy.utils.timeNowUTC
 import com.ivy.legacy.utils.toLowerCaseLocal
@@ -450,9 +450,9 @@ class ReportViewModel @Inject constructor(
         if (!filter.validate()) return
 
         ivyContext.createNewFile(
-            "Report (${
-                timeNowUTC().formatNicelyWithTime(noWeekDay = true)
-            }).csv"
+            "IvyWalletReport-${
+                timeNowUTC().getISOFormattedDateTime()
+            }.csv"
         ) { fileUri ->
             viewModelScope.launch {
                 loading.value = true

--- a/screen/settings/src/main/java/com/ivy/settings/SettingsViewModel.kt
+++ b/screen/settings/src/main/java/com/ivy/settings/SettingsViewModel.kt
@@ -21,7 +21,7 @@ import com.ivy.frp.monad.Res
 import com.ivy.legacy.IvyWalletCtx
 import com.ivy.legacy.LogoutLogic
 import com.ivy.legacy.domain.action.settings.UpdateSettingsAct
-import com.ivy.legacy.utils.formatNicelyWithTime
+import com.ivy.legacy.utils.getISOFormattedDateTime
 import com.ivy.legacy.utils.ioThread
 import com.ivy.legacy.utils.timeNowUTC
 import com.ivy.legacy.utils.uiThread
@@ -257,9 +257,9 @@ class SettingsViewModel @Inject constructor(
 
     private fun exportToCSV(rootScreen: RootScreen) {
         ivyContext.createNewFile(
-            "Ivy Wallet (${
-                timeNowUTC().formatNicelyWithTime(noWeekDay = true)
-            }).csv"
+            "IvyWalletExport_${
+                timeNowUTC().getISOFormattedDateTime()
+            }.csv"
         ) { fileUri ->
             viewModelScope.launch {
                 exportCSVLogic.exportToFile(
@@ -276,9 +276,9 @@ class SettingsViewModel @Inject constructor(
 
     private fun exportToZip(rootScreen: RootScreen) {
         ivyContext.createNewFile(
-            "Ivy Wallet (${
-                timeNowUTC().formatNicelyWithTime(noWeekDay = true)
-            }).zip"
+            "IvyWalletBackup_${
+                timeNowUTC().getISOFormattedDateTime()
+            }.zip"
         ) { fileUri ->
             viewModelScope.launch(Dispatchers.IO) {
                 progressState.value = true

--- a/temp/legacy-code/src/main/java/com/ivy/legacy/utils/DateExt.kt
+++ b/temp/legacy-code/src/main/java/com/ivy/legacy/utils/DateExt.kt
@@ -78,6 +78,8 @@ fun LocalDateTime.formatNicely(
     }
 }
 
+fun LocalDateTime.getISOFormattedDateTime(): String = this.formatLocal("yyyyMMdd-HHmm")
+
 fun LocalDateTime.formatNicelyWithTime(
     noWeekDay: Boolean = true,
     zone: ZoneId = ZoneOffset.systemDefault()


### PR DESCRIPTION
Unfortunately [this](https://github.com/Ivy-Apps/ivy-wallet/commit/b04e918e00f0e9aae69608242ce42e69fd6d7a27) commit reverted all of the https://github.com/Ivy-Apps/ivy-wallet/pull/3012 efforts. This PR brings it back and fixes a problem with the `:` character, which is not handled correctly by certain operating systems.