### PR TITLE
Fixes issue #3181 Quick Settings Tile Small Icon

### DIFF
--- a/shared/ui/core/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/shared/ui/core/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,13 +1,13 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="108dp"
-    android:height="108dp"
+    android:width="24dp"
+    android:height="24dp"
     android:viewportWidth="108"
     android:viewportHeight="108">
     <group
-        android:scaleX="0.0432"
-        android:scaleY="0.0432"
-        android:translateX="10.8"
-        android:translateY="10.8">
+        android:scaleX="0.07"
+        android:scaleY="0.07"
+        android:translateX="-17"
+        android:translateY="-17">
         <path
             android:pathData="M1573.86,758.34q-3.69,-7.44 -7.56,-14.78A295.67,295.67 0,0 0,1304.83 586H695.17a295.55,295.55 0,0 0,-64.93 7.21l494.06,-165c104.11,-34.77 220.42,-4 300.08,80C1489.45,576.89 1541.41,661.4 1573.86,758.34Z"
             android:fillColor="#efeef0" />


### PR DESCRIPTION
Fixed Issue #3181 

i have adjust the ic_launcher_foreground so that it shows the the quick settings tile perfectly.


<img src="https://github.com/Ivy-Apps/ivy-wallet/assets/82767208/3aaaafb2-249a-4f28-9243-744fc13c94ea" width="200">

<img src="https://github.com/Ivy-Apps/ivy-wallet/assets/82767208/f0e9ea39-d806-4a79-9404-b6e10152ea3a" width="200">


