### PR TITLE
Fix: Prevent consecutive operator input in CalculatorModal

### DIFF
--- a/temp/legacy-code/src/main/java/com/ivy/legacy/legacy/ui/theme/modal/edit/CalculatorModal.kt
+++ b/temp/legacy-code/src/main/java/com/ivy/legacy/legacy/ui/theme/modal/edit/CalculatorModal.kt
@@ -178,6 +178,7 @@ fun BoxWithConstraintsScope.CalculatorModal(
         Spacer(Modifier.height(24.dp))
     }
 }
+
 private fun handleOperator(expression: String, operator: String): String {
     return if (expression.isNotEmpty() && expression.last().isOperator()) {
         expression.dropLast(1) + operator
@@ -186,8 +187,9 @@ private fun handleOperator(expression: String, operator: String): String {
     }
 }
 
-private fun Char.isOperator(): Boolean {
-    return this == '+' || this == '−' || this == '×' || this == '÷'
+fun Char.isOperator(): Boolean = when(this) {
+    '+', '−','×', '÷' -> true
+    else -> false
 }
 
 private fun formatExpression(expression: String, currency: String): String {

--- a/temp/legacy-code/src/main/java/com/ivy/legacy/legacy/ui/theme/modal/edit/CalculatorModal.kt
+++ b/temp/legacy-code/src/main/java/com/ivy/legacy/legacy/ui/theme/modal/edit/CalculatorModal.kt
@@ -117,7 +117,7 @@ fun BoxWithConstraintsScope.CalculatorModal(
                     text = "÷",
                     testTag = "key_/"
                 ) {
-                    expression += "÷"
+                    expression = handleOperator(expression, "÷")
                 }
             },
             FirstRowExtra = {
@@ -125,7 +125,7 @@ fun BoxWithConstraintsScope.CalculatorModal(
                     text = "×",
                     testTag = "key_*"
                 ) {
-                    expression += "×"
+                    expression = handleOperator(expression, "×")
                 }
             },
             SecondRowExtra = {
@@ -133,7 +133,7 @@ fun BoxWithConstraintsScope.CalculatorModal(
                     text = "−",
                     testTag = "key_-"
                 ) {
-                    expression += "−"
+                    expression = handleOperator(expression, "−")
                 }
             },
             ThirdRowExtra = {
@@ -141,7 +141,7 @@ fun BoxWithConstraintsScope.CalculatorModal(
                     text = "+",
                     testTag = "key_+"
                 ) {
-                    expression += "+"
+                    expression = handleOperator(expression, "+")
                 }
             },
             FourthRowExtra = {
@@ -177,6 +177,17 @@ fun BoxWithConstraintsScope.CalculatorModal(
 
         Spacer(Modifier.height(24.dp))
     }
+}
+private fun handleOperator(expression: String, operator: String): String {
+    return if (expression.isNotEmpty() && expression.last().isOperator()) {
+        expression.dropLast(1) + operator
+    } else {
+        expression + operator
+    }
+}
+
+private fun Char.isOperator(): Boolean {
+    return this == '+' || this == '−' || this == '×' || this == '÷'
 }
 
 private fun formatExpression(expression: String, currency: String): String {

--- a/temp/legacy-code/src/main/java/com/ivy/legacy/legacy/ui/theme/modal/edit/CalculatorModal.kt
+++ b/temp/legacy-code/src/main/java/com/ivy/legacy/legacy/ui/theme/modal/edit/CalculatorModal.kt
@@ -187,8 +187,8 @@ private fun handleOperator(expression: String, operator: String): String {
     }
 }
 
-fun Char.isOperator(): Boolean = when(this) {
-    '+', '−','×', '÷' -> true
+fun Char.isOperator(): Boolean = when (this) {
+    '+', '−', '×', '÷' -> true
     else -> false
 }
 


### PR DESCRIPTION
## Pull request (PR) checklist
Please check if your pull request fulfills the following requirements:
<!--💡 Tip: Tick checkboxes like this: [x] 💡-->
- [x] I've read the [Contribution Guidelines](https://github.com/Ivy-Apps/ivy-wallet/blob/main/CONTRIBUTING.md) and my PR doesn't break the rules.
- [x] I've read and understand the [Developer Guidelines](https://github.com/Ivy-Apps/ivy-wallet/blob/main/docs/Guidelines.md).
- [x] I confirm that I've run the code locally and everything works as expected.
- [x] My PR includes only the necessary changes to fix the issue (i.e., no unnecessary files or lines of code are changed).
- [x] 🎬 I've attached a **screen recording** of using the new code to the next paragraph (if applicable).
<!--💡 Tip: Drag & drop the video here. 💡-->

## What's changed?
Resolved an issue in the CalculatorModal where consecutive operators could be added, resulting in invalid expressions.

- Updated the handleOperator function to ensure only one operator is added at a time.
- Replaced the last operator if a new operator is pressed.
- Ensured the input behaves like a standard calculator.

This change improves the user experience by preventing invalid expressions and aligning the calculator's behavior with user expectations.

Before
https://github.com/user-attachments/assets/c4cb087d-e360-44b1-90fd-38f3436e5e04

After:
https://github.com/user-attachments/assets/085816dc-9ad7-459a-b48e-c35e3bd649ad

