### PR TITLE
Fix incorrect time display after saving and reopening transactions

### DIFF
--- a/screen/edit-transaction/src/main/java/com/ivy/transaction/EditTransactionViewModel.kt
+++ b/screen/edit-transaction/src/main/java/com/ivy/transaction/EditTransactionViewModel.kt
@@ -704,7 +704,7 @@ class EditTransactionViewModel @Inject constructor(
                     dateTime = when {
                         loadedTransaction().dateTime == null &&
                                 dueDate.value == null -> {
-                            timeNowUTC()
+                            getTrueDate(LocalDate.now(),timeNowLocal().toLocalTime())
                         }
 
                         else -> loadedTransaction().dateTime


### PR DESCRIPTION


## Pull request (PR) checklist

Please check if your pull request fulfills the following requirements:
<!--💡 Tip: Tick checkboxes like this: [x] 💡-->
- [x] I've read the [Contribution Guidelines](https://github.com/Ivy-Apps/ivy-wallet/blob/main/CONTRIBUTING.md) and my PR doesn't break the rules.
- [x] I've read and understand the [Developer Guidelines](https://github.com/Ivy-Apps/ivy-wallet/blob/main/docs/Guidelines.md).
- [x] I confirm that I've run the code locally and everything works as expected.
- [x] My PR includes only the necessary changes to fix the issue (i.e., no unnecessary files or lines of code are changed).
- [x] 🎬 I've attached a **screen recording** of using the new code to the next paragraph (if applicable).

## Screen recording of your changes (if applicable):
https://github.com/user-attachments/assets/1b4fc370-3232-4d51-8f09-f7da6c9e1e3c

## What's changed?
Resolved the issue where the time and date for transactions were incorrectly displayed after saving and reopening. The time now remains consistent and accurate as intended.

Before|After
---|--
https://github.com/user-attachments/assets/176d36f2-9d6c-4245-9be7-83daa28b3226 | https://github.com/user-attachments/assets/1b4fc370-3232-4d51-8f09-f7da6c9e1e3c

## Does this PR close any GitHub issues? (do not delete)

- Closes #3424
