### PR TITLE
Fix #3432 Recurring expenses spawn at UTC timing instead of local time

### DIFF
--- a/temp/legacy-code/src/main/java/com/ivy/legacy/domain/action/viewmodel/home/DueTrnsInfoAct.kt
+++ b/temp/legacy-code/src/main/java/com/ivy/legacy/domain/action/viewmodel/home/DueTrnsInfoAct.kt
@@ -1,10 +1,10 @@
 package com.ivy.wallet.domain.action.viewmodel.home
 
+import com.ivy.base.time.TimeConverter
 import com.ivy.data.model.Transaction
 import com.ivy.frp.action.FPAction
 import com.ivy.frp.lambda
 import com.ivy.frp.then
-import com.ivy.legacy.utils.dateNowUTC
 import com.ivy.wallet.domain.action.account.AccountByIdAct
 import com.ivy.wallet.domain.action.exchange.ExchangeAct
 import com.ivy.wallet.domain.action.exchange.actInput
@@ -16,20 +16,24 @@ import com.ivy.wallet.domain.pure.exchange.exchangeInBaseCurrency
 import com.ivy.wallet.domain.pure.transaction.expenses
 import com.ivy.wallet.domain.pure.transaction.incomes
 import com.ivy.wallet.domain.pure.transaction.sumTrns
+import java.time.Instant
 import java.time.LocalDate
 import javax.inject.Inject
 
 class DueTrnsInfoAct @Inject constructor(
     private val dueTrnsAct: DueTrnsAct,
     private val accountByIdAct: AccountByIdAct,
-    private val exchangeAct: ExchangeAct
+    private val exchangeAct: ExchangeAct,
+    private val timeConverter: TimeConverter
 ) : FPAction<DueTrnsInfoAct.Input, DueTrnsInfoAct.Output>() {
 
     override suspend fun Input.compose(): suspend () -> Output =
         suspend {
             range
         } then dueTrnsAct then { trns ->
-            val dateNow = dateNowUTC()
+            val dateNow = with(timeConverter) {
+                Instant.now().toLocalDate()
+            }
             trns.filter {
                 this.dueFilter(it, dateNow)
             }

--- a/temp/legacy-code/src/main/java/com/ivy/legacy/domain/action/viewmodel/home/DueTrnsInfoAct.kt
+++ b/temp/legacy-code/src/main/java/com/ivy/legacy/domain/action/viewmodel/home/DueTrnsInfoAct.kt
@@ -1,6 +1,6 @@
 package com.ivy.wallet.domain.action.viewmodel.home
 
-import com.ivy.base.time.TimeConverter
+import com.ivy.base.time.TimeProvider
 import com.ivy.data.model.Transaction
 import com.ivy.frp.action.FPAction
 import com.ivy.frp.lambda
@@ -16,7 +16,6 @@ import com.ivy.wallet.domain.pure.exchange.exchangeInBaseCurrency
 import com.ivy.wallet.domain.pure.transaction.expenses
 import com.ivy.wallet.domain.pure.transaction.incomes
 import com.ivy.wallet.domain.pure.transaction.sumTrns
-import java.time.Instant
 import java.time.LocalDate
 import javax.inject.Inject
 
@@ -24,16 +23,14 @@ class DueTrnsInfoAct @Inject constructor(
     private val dueTrnsAct: DueTrnsAct,
     private val accountByIdAct: AccountByIdAct,
     private val exchangeAct: ExchangeAct,
-    private val timeConverter: TimeConverter
+    private val timeProvider: TimeProvider
 ) : FPAction<DueTrnsInfoAct.Input, DueTrnsInfoAct.Output>() {
 
     override suspend fun Input.compose(): suspend () -> Output =
         suspend {
             range
         } then dueTrnsAct then { trns ->
-            val dateNow = with(timeConverter) {
-                Instant.now().toLocalDate()
-            }
+            val dateNow = timeProvider.localDateNow()
             trns.filter {
                 this.dueFilter(it, dateNow)
             }

--- a/temp/legacy-code/src/main/java/com/ivy/legacy/legacy/ui/theme/modal/RecurringRuleModal.kt
+++ b/temp/legacy-code/src/main/java/com/ivy/legacy/legacy/ui/theme/modal/RecurringRuleModal.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.ivy.data.model.IntervalType
+import com.ivy.design.api.LocalTimeProvider
 import com.ivy.design.l0_system.UI
 import com.ivy.design.l0_system.style
 import com.ivy.legacy.IvyWalletCtx
@@ -47,7 +48,6 @@ import com.ivy.legacy.utils.hideKeyboard
 import com.ivy.legacy.utils.onScreenStart
 import com.ivy.design.utils.thenIf
 import com.ivy.legacy.utils.rememberInteractionSource
-import com.ivy.legacy.utils.timeNowLocal
 import com.ivy.ui.R
 import com.ivy.wallet.ui.theme.Gradient
 import com.ivy.wallet.ui.theme.GradientIvy
@@ -80,8 +80,9 @@ fun BoxWithConstraintsScope.RecurringRuleModal(
     dismiss: () -> Unit,
     onRuleChanged: (LocalDateTime, oneTime: Boolean, Int?, IntervalType?) -> Unit,
 ) {
+    val localTimeProvider = LocalTimeProvider.current
     var startDate by remember(modal) {
-        mutableStateOf(modal?.initialStartDate ?: timeNowLocal())
+        mutableStateOf(modal?.initialStartDate ?: localTimeProvider.localNow())
     }
     var oneTime by remember(modal) {
         mutableStateOf(modal?.initialOneTime ?: false)

--- a/temp/legacy-code/src/main/java/com/ivy/legacy/legacy/ui/theme/modal/RecurringRuleModal.kt
+++ b/temp/legacy-code/src/main/java/com/ivy/legacy/legacy/ui/theme/modal/RecurringRuleModal.kt
@@ -80,9 +80,9 @@ fun BoxWithConstraintsScope.RecurringRuleModal(
     dismiss: () -> Unit,
     onRuleChanged: (LocalDateTime, oneTime: Boolean, Int?, IntervalType?) -> Unit,
 ) {
-    val localTimeProvider = LocalTimeProvider.current
+    val timeProvider = LocalTimeProvider.current
     var startDate by remember(modal) {
-        mutableStateOf(modal?.initialStartDate ?: localTimeProvider.localNow())
+        mutableStateOf(modal?.initialStartDate ?: timeProvider.localNow())
     }
     var oneTime by remember(modal) {
         mutableStateOf(modal?.initialOneTime ?: false)

--- a/temp/legacy-code/src/main/java/com/ivy/legacy/legacy/ui/theme/modal/RecurringRuleModal.kt
+++ b/temp/legacy-code/src/main/java/com/ivy/legacy/legacy/ui/theme/modal/RecurringRuleModal.kt
@@ -47,7 +47,7 @@ import com.ivy.legacy.utils.hideKeyboard
 import com.ivy.legacy.utils.onScreenStart
 import com.ivy.design.utils.thenIf
 import com.ivy.legacy.utils.rememberInteractionSource
-import com.ivy.legacy.utils.timeNowUTC
+import com.ivy.legacy.utils.timeNowLocal
 import com.ivy.ui.R
 import com.ivy.wallet.ui.theme.Gradient
 import com.ivy.wallet.ui.theme.GradientIvy
@@ -81,7 +81,7 @@ fun BoxWithConstraintsScope.RecurringRuleModal(
     onRuleChanged: (LocalDateTime, oneTime: Boolean, Int?, IntervalType?) -> Unit,
 ) {
     var startDate by remember(modal) {
-        mutableStateOf(modal?.initialStartDate ?: timeNowUTC())
+        mutableStateOf(modal?.initialStartDate ?: timeNowLocal())
     }
     var oneTime by remember(modal) {
         mutableStateOf(modal?.initialOneTime ?: false)


### PR DESCRIPTION
## Pull request (PR) checklist

Please check if your pull request fulfills the following requirements:
<!--💡 Tip: Tick checkboxes like this: [x] 💡-->
- [x] I've read the [Contribution Guidelines](https://github.com/Ivy-Apps/ivy-wallet/blob/main/CONTRIBUTING.md) and my PR doesn't break the rules.
- [x] I've read and understand the [Developer Guidelines](https://github.com/Ivy-Apps/ivy-wallet/blob/main/docs/Guidelines.md).
- [x] I confirm that I've run the code locally and everything works as expected.
- [x] My PR includes only the necessary changes to fix the issue (i.e., no unnecessary files or lines of code are changed).
- [ ] 🎬 I've attached a **screen recording** of using the new code to the next paragraph (if applicable).

## Screen recording of your changes (if applicable):
No

## What's changed?
Assume that on September 29, 2024, we create a recurring expense named **`MyRecurrentExpense`**. Consequently, an entry for **`MyRecurrentExpense`** appears in the **`upcoming section`** of the home screen for September 29. Previously, this entry was moved to the **`overdue section`** at 12:00 AM UTC rather than 12:00 AM local time. Now, the entry is moved to the **`overdue section`** at 12:00 AM local time.

**N.B:** Expenses from September 29 will move to the **`overdue section`** on September 30 at 12:00 AM local time.

## Risk factors

**What may go wrong if we merge your PR?**
No

**In what cases won't your code work?**
No

## Does this PR close any GitHub issues? (do not delete)

- Closes N/A

<!--❗For example: - Closes #123 ❗-->
<!--⚠️ If done correctly, you'll see the issue title linked on the PR preview. ⚠️-->
<!--💡 Tip: Multiple issues:
- Closes #{ISSUE_NUMBER_1}, closes #{ISSUE_NUMBER_2}, closes #{ISSUE_NUMBER_3}
-->
<!-- If the PR doesn't close any GitHub issues, type "Closes N/A" to pass the CI check. -->