### PR TITLE
Add setting to toggle keypad layout between numeric & standard

### DIFF
--- a/shared/domain/src/main/java/com/ivy/domain/di/IvyCoreBindingsModule.kt
+++ b/shared/domain/src/main/java/com/ivy/domain/di/IvyCoreBindingsModule.kt
@@ -4,6 +4,7 @@ import com.ivy.domain.features.Features
 import com.ivy.domain.features.IvyFeatures
 import dagger.Binds
 import dagger.Module
+import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 
@@ -12,4 +13,10 @@ import dagger.hilt.components.SingletonComponent
 interface IvyCoreBindingsModule {
     @Binds
     fun bindFeatures(features: IvyFeatures): Features
+}
+
+@EntryPoint
+@InstallIn(SingletonComponent::class)
+interface FeaturesEntryPoint {
+    fun getFeatures(): Features
 }

--- a/shared/domain/src/main/java/com/ivy/domain/features/Features.kt
+++ b/shared/domain/src/main/java/com/ivy/domain/features/Features.kt
@@ -8,6 +8,7 @@ interface Features {
     val showCategorySearchBar: BoolFeature
     val hideTotalBalance: BoolFeature
     val showDecimalNumber: BoolFeature
+    val standardKeypadLayout: BoolFeature
 
     val allFeatures: List<BoolFeature>
 }

--- a/shared/domain/src/main/java/com/ivy/domain/features/IvyFeatures.kt
+++ b/shared/domain/src/main/java/com/ivy/domain/features/IvyFeatures.kt
@@ -59,6 +59,14 @@ class IvyFeatures @Inject constructor() : Features {
         defaultValue = true
     )
 
+    override val standardKeypadLayout = BoolFeature(
+        key = "enable_standard_keypad_layout",
+        group = FeatureGroup.Other,
+        name = "Standard keypad layout",
+        description = "Enable standard phone keypad layout instead of numeric calculator layout",
+        defaultValue = false
+    )
+
     override val allFeatures: List<BoolFeature>
         get() = listOf(
             sortCategoriesAscending,
@@ -67,6 +75,7 @@ class IvyFeatures @Inject constructor() : Features {
             showTitleSuggestions,
             showCategorySearchBar,
             hideTotalBalance,
+            standardKeypadLayout
             /* will be uncommented when this functionality
              * will be available across the application in up-coming PRs
             showDecimalNumber

--- a/temp/legacy-code/src/main/java/com/ivy/legacy/legacy/ui/theme/modal/edit/AmountModal.kt
+++ b/temp/legacy-code/src/main/java/com/ivy/legacy/legacy/ui/theme/modal/edit/AmountModal.kt
@@ -328,10 +328,12 @@ fun AmountKeyboard(
      **/
 
     val context = LocalContext.current
-    val features = EntryPointAccessors.fromApplication(
-        context.applicationContext,
-        FeaturesEntryPoint::class.java
-    ).getFeatures()
+    val features = remember {
+        EntryPointAccessors.fromApplication(
+            context.applicationContext,
+            FeaturesEntryPoint::class.java
+        ).getFeatures()
+    }
     val isStandardLayout = features.standardKeypadLayout.asEnabledState()
 
     // Decide the order of the numbers based on the keypad layout


### PR DESCRIPTION
## Pull request (PR) checklist

Please check if your pull request fulfills the following requirements:
<!--💡 Tip: Tick checkboxes like this: [x] 💡-->
- [x] I've read the [Contribution Guidelines](https://github.com/Ivy-Apps/ivy-wallet/blob/main/CONTRIBUTING.md) and my PR doesn't break the rules.
- [x] I've read and understand the [Developer Guidelines](https://github.com/Ivy-Apps/ivy-wallet/blob/main/docs/Guidelines.md).
- [x] I confirm that I've run the code locally and everything works as expected.
- [x] My PR includes only the necessary changes to fix the issue (i.e., no unnecessary files or lines of code are changed).
- [x] 🎬 I've attached a **screen recording** of using the new code to the next paragraph (if applicable).

## Screen recording of your changes (if applicable):
https://github.com/user-attachments/assets/32b0f1ef-c86f-4631-a81a-07284d269bd1

## What's changed?
We just had the calculator like numeric pad in the keypad or the `AmountKeyboard`. No you can toggle the setting in settings and switch between standard and numeric style keypad.

Describe with a few bullets **what's new:**
- I've added setting to toggle keypad layout between numeric & standard

## Risk factors
- Not a dangerous feature.
- Code wise, adding the state directly inside the composable might be an anti pattern but its fine for a simple static composable.
  - The setting is only togglable from the settings so frequent recompositions isn't a issue when the keyboard is already drawn on screen.
  - This way,`AmountKeyboard` is self-contained, making it easy to reuse without passing parameters.
  - Layout changes are rare with the keyboard rendering, so recomposition has minimal impact on performance.


**What may go wrong if we merge your PR?**
- Not a dangerous commit

**In what cases won't your code work?**
- N/A

## Does this PR close any GitHub issues?

- Closes #3598

<!--❗For example: - Closes #123 ❗-->
<!--⚠️ If done correctly, you'll see the issue title linked on the PR preview. ⚠️-->
<!--💡 Tip: Multiple issues:
- Closes #{ISSUE_NUMBER_1}, closes #{ISSUE_NUMBER_2}, closes #{ISSUE_NUMBER_3}
-->
<!-- If the PR doesn't close any GitHub issues, type "Closes N/A" to pass the CI check. -->

## Troubleshooting GitHub Actions (CI) failures ❌
Pull request checks failing? Read our [CI Troubleshooting guide](https://github.com/Ivy-Apps/ivy-wallet/blob/main/docs/CI-Troubleshooting.md).