### PR TITLE
Refactor TransactionCard UI to support compactMode

### DIFF
--- a/screen/home/src/main/java/com/ivy/home/HomeState.kt
+++ b/screen/home/src/main/java/com/ivy/home/HomeState.kt
@@ -33,5 +33,6 @@ data class HomeState(
     val customerJourneyCards: ImmutableList<CustomerJourneyCardModel>,
     val hideBalance: Boolean,
     val hideIncome: Boolean,
-    val expanded: Boolean
+    val expanded: Boolean,
+    val compactTransactionsModeEnabled: Boolean
 )

--- a/screen/home/src/main/java/com/ivy/home/HomeTab.kt
+++ b/screen/home/src/main/java/com/ivy/home/HomeTab.kt
@@ -187,7 +187,7 @@ fun BoxWithConstraintsScope.HomeUi(
 
             stats = uiState.stats,
             history = uiState.history,
-
+            compactTransactionsEnabled = uiState.compactTransactionsModeEnabled,
             customerJourneyCards = uiState.customerJourneyCards,
 
             onPayOrGet = forward<Transaction>() then2 {
@@ -295,7 +295,7 @@ fun HomeLazyColumn(
     balance: BigDecimal,
     stats: IncomeExpensePair,
     history: ImmutableList<TransactionHistoryItem>,
-
+    compactTransactionsEnabled: Boolean,
     customerJourneyCards: ImmutableList<CustomerJourneyCardModel>,
 
     setUpcomingExpanded: (Boolean) -> Unit,
@@ -387,7 +387,8 @@ fun HomeLazyColumn(
                 )
             ),
             onSkipTransaction = onSkipTransaction,
-            onSkipAllTransactions = onSkipAllTransactions
+            onSkipAllTransactions = onSkipAllTransactions,
+            compactModeEnabled = compactTransactionsEnabled
         )
     }
 }
@@ -428,7 +429,8 @@ private fun BoxWithConstraintsScope.PreviewHomeTab(isDark: Boolean = false) {
                 period = TimePeriod(month = Month.monthsList().first(), year = 2023),
                 hideBalance = false,
                 hideIncome = false,
-                expanded = false
+                expanded = false,
+                compactTransactionsModeEnabled = false
             ),
             onEvent = {}
         )

--- a/screen/home/src/main/java/com/ivy/home/HomeViewModel.kt
+++ b/screen/home/src/main/java/com/ivy/home/HomeViewModel.kt
@@ -15,6 +15,7 @@ import com.ivy.base.time.TimeProvider
 import com.ivy.data.model.primitive.AssetCode
 import com.ivy.data.repository.CategoryRepository
 import com.ivy.data.repository.mapper.TransactionMapper
+import com.ivy.domain.features.Features
 import com.ivy.domain.usecase.exchange.SyncExchangeRatesUseCase
 import com.ivy.frp.fixUnit
 import com.ivy.frp.then
@@ -81,6 +82,7 @@ class HomeViewModel @Inject constructor(
     private val upcomingAct: UpcomingAct,
     private val overdueAct: OverdueAct,
     private val hasTrnsAct: HasTrnsAct,
+    private val features: Features,
     private val startDayOfMonthAct: StartDayOfMonthAct,
     private val shouldHideBalanceAct: ShouldHideBalanceAct,
     private val shouldHideIncomeAct: ShouldHideIncomeAct,
@@ -151,7 +153,8 @@ class HomeViewModel @Inject constructor(
             customerJourneyCards = getCustomerJourneyCards(),
             hideBalance = getHideBalance(),
             expanded = getExpanded(),
-            hideIncome = getHideIncome()
+            hideIncome = getHideIncome(),
+            compactTransactionsModeEnabled = getCompactTransactionsMode()
         )
     }
 
@@ -223,6 +226,11 @@ class HomeViewModel @Inject constructor(
     @Composable
     private fun getHideIncome(): Boolean {
         return hideIncome
+    }
+
+    @Composable
+    private fun getCompactTransactionsMode(): Boolean {
+        return features.compactTransactionsMode.asEnabledState()
     }
 
     override fun onEvent(event: HomeEvent) {

--- a/screen/reports/src/main/java/com/ivy/reports/ReportScreen.kt
+++ b/screen/reports/src/main/java/com/ivy/reports/ReportScreen.kt
@@ -270,7 +270,8 @@ private fun BoxWithConstraintsScope.UI(
                 },
                 onSkipAllTransactions = {
                     onEventHandler.invoke(ReportScreenEvent.SkipTransactionsLegacy(transactions = it))
-                }
+                },
+                compactModeEnabled = state.compactTransactionsModeEnabled
             )
         } else {
             item {

--- a/screen/reports/src/main/java/com/ivy/reports/ReportScreenState.kt
+++ b/screen/reports/src/main/java/com/ivy/reports/ReportScreenState.kt
@@ -33,5 +33,6 @@ data class ReportScreenState(
     val filterOverlayVisible: Boolean = false,
     val showTransfersAsIncExpCheckbox: Boolean = false,
     val treatTransfersAsIncExp: Boolean = false,
-    val allTags: ImmutableList<Tag> = persistentListOf()
+    val allTags: ImmutableList<Tag> = persistentListOf(),
+    val compactTransactionsModeEnabled: Boolean = false
 )

--- a/screen/reports/src/main/java/com/ivy/reports/ReportViewModel.kt
+++ b/screen/reports/src/main/java/com/ivy/reports/ReportViewModel.kt
@@ -33,6 +33,7 @@ import com.ivy.data.repository.mapper.TransactionMapper
 import com.ivy.data.temp.migration.getTransactionType
 import com.ivy.data.temp.migration.getValue
 import com.ivy.domain.RootScreen
+import com.ivy.domain.features.Features
 import com.ivy.domain.usecase.csv.ExportCsvUseCase
 import com.ivy.frp.filterSuspend
 import com.ivy.legacy.IvyWalletCtx
@@ -80,6 +81,7 @@ class ReportViewModel @Inject constructor(
     private val ivyContext: IvyWalletCtx,
     private val exchangeAct: ExchangeAct,
     private val accountsAct: AccountsAct,
+    private val features: Features,
     private val categoryRepository: CategoryRepository,
     private val trnsWithDateDivsAct: TrnsWithDateDivsAct,
     private val calcTrnsIncomeExpenseAct: CalcTrnsIncomeExpenseAct,
@@ -157,8 +159,14 @@ class ReportViewModel @Inject constructor(
             upcomingExpenses = upcomingExpenses,
             upcomingIncome = upcomingIncome,
             upcomingTransactions = upcomingTransactions,
-            allTags = allTags
+            allTags = allTags,
+            compactTransactionsModeEnabled = getCompactTransactionsMode()
         )
+    }
+
+    @Composable
+    private fun getCompactTransactionsMode(): Boolean {
+        return features.compactTransactionsMode.asEnabledState()
     }
 
     override fun onEvent(event: ReportScreenEvent) {

--- a/screen/search/src/main/java/com/ivy/search/SearchScreen.kt
+++ b/screen/search/src/main/java/com/ivy/search/SearchScreen.kt
@@ -105,7 +105,8 @@ private fun SearchUi(
                 onPayOrGet = { },
                 emptyStateTitle = emptyStateTitle,
                 emptyStateText = emptyStateText,
-                dateDividerMarginTop = 16.dp
+                dateDividerMarginTop = 16.dp,
+                compactModeEnabled = uiState.compactTransactionsModeEnabled
             )
 
             item {
@@ -134,7 +135,8 @@ private fun Preview(isDark: Boolean = false) {
                 transactions = persistentListOf(),
                 baseCurrency = "",
                 accounts = persistentListOf(),
-                categories = persistentListOf()
+                categories = persistentListOf(),
+                compactTransactionsModeEnabled = false
             ),
             onEvent = {}
         )

--- a/screen/search/src/main/java/com/ivy/search/SearchState.kt
+++ b/screen/search/src/main/java/com/ivy/search/SearchState.kt
@@ -10,5 +10,6 @@ data class SearchState(
     val transactions: ImmutableList<TransactionHistoryItem>,
     val baseCurrency: String,
     val accounts: ImmutableList<Account>,
-    val categories: ImmutableList<Category>
+    val categories: ImmutableList<Category>,
+    val compactTransactionsModeEnabled: Boolean,
 )

--- a/screen/search/src/main/java/com/ivy/search/SearchViewModel.kt
+++ b/screen/search/src/main/java/com/ivy/search/SearchViewModel.kt
@@ -10,6 +10,7 @@ import com.ivy.data.model.primitive.NotBlankTrimmedString
 import com.ivy.ui.ComposeViewModel
 import com.ivy.data.model.Category
 import com.ivy.data.repository.CategoryRepository
+import com.ivy.domain.features.Features
 import com.ivy.legacy.datamodel.Account
 import com.ivy.legacy.utils.getDefaultFIATCurrency
 import com.ivy.legacy.utils.ioThread
@@ -29,6 +30,7 @@ import javax.inject.Inject
 class SearchViewModel @Inject constructor(
     private val trnsWithDateDivsAct: TrnsWithDateDivsAct,
     private val accountsAct: AccountsAct,
+    private val features: Features,
     private val categoryRepository: CategoryRepository,
     private val baseCurrencyAct: BaseCurrencyAct,
     private val allTrnsAct: AllTrnsAct
@@ -52,8 +54,14 @@ class SearchViewModel @Inject constructor(
             transactions = transactions.value,
             baseCurrency = baseCurrency.value,
             accounts = accounts.value,
-            categories = categories.value
+            categories = categories.value,
+            compactTransactionsModeEnabled = getCompactTransactionsMode()
         )
+    }
+
+    @Composable
+    private fun getCompactTransactionsMode(): Boolean {
+        return features.compactTransactionsMode.asEnabledState()
     }
 
     override fun onEvent(event: SearchEvent) {

--- a/screen/transactions/src/main/java/com/ivy/transactions/TransactionsScreen.kt
+++ b/screen/transactions/src/main/java/com/ivy/transactions/TransactionsScreen.kt
@@ -201,7 +201,8 @@ fun BoxWithConstraintsScope.TransactionsScreen(screen: TransactionsScreen) {
         onChoosePeriodModal = {
             viewModel.onEvent(TransactionsEvent.OnChoosePeriodModalData(it))
         },
-        choosePeriodModal = uiState.choosePeriodModal
+        choosePeriodModal = uiState.choosePeriodModal,
+        compactTransactionsEnabled = uiState.compactTransactionsModeEnabled
     )
 }
 
@@ -231,7 +232,7 @@ private fun BoxWithConstraintsScope.UI(
     choosePeriodModal: ChoosePeriodModalData?,
 
     history: ImmutableList<TransactionHistoryItem>,
-
+    compactTransactionsEnabled: Boolean,
     onPreviousMonth: () -> Unit,
     onNextMonth: () -> Unit,
     onSetPeriod: (TimePeriod) -> Unit,
@@ -240,7 +241,6 @@ private fun BoxWithConstraintsScope.UI(
     onDelete: () -> Unit,
     deleteModal1Visible: Boolean,
     onDeleteModal1Visible: (Boolean) -> Unit,
-
     initWithTransactions: Boolean = false,
     treatTransfersAsIncomeExpense: Boolean = false,
     upcomingExpanded: Boolean = true,
@@ -410,7 +410,6 @@ private fun BoxWithConstraintsScope.UI(
                 lastItemSpacer = with(density) {
                     (ivyContext.screenHeight * 0.7f).toDp()
                 },
-
                 onPayOrGet = onPayOrGet,
                 onSkipTransaction = onSkipTransaction,
                 onSkipAllTransactions = {
@@ -425,7 +424,8 @@ private fun BoxWithConstraintsScope.UI(
                         timeConverter = timeConverter,
                         timeFormatter = timeFormatter,
                     )
-                )
+                ),
+                compactModeEnabled = compactTransactionsEnabled,
             )
         }
     }
@@ -857,6 +857,7 @@ private fun BoxWithConstraintsScope.Preview_empty() {
             onChoosePeriodModal = {},
             choosePeriodModal = null,
             screen = TransactionsScreen(),
+            compactTransactionsEnabled = false
         )
     }
 }
@@ -903,6 +904,7 @@ private fun BoxWithConstraintsScope.Preview_crypto() {
             onChoosePeriodModal = {},
             choosePeriodModal = null,
             screen = TransactionsScreen(),
+            compactTransactionsEnabled = false
         )
     }
 }
@@ -949,6 +951,7 @@ private fun BoxWithConstraintsScope.Preview_empty_upcoming() {
             onChoosePeriodModal = {},
             choosePeriodModal = null,
             screen = TransactionsScreen(),
+            compactTransactionsEnabled = false
         )
     }
 }

--- a/screen/transactions/src/main/java/com/ivy/transactions/TransactionsState.kt
+++ b/screen/transactions/src/main/java/com/ivy/transactions/TransactionsState.kt
@@ -37,4 +37,5 @@ data class TransactionsState(
     val skipAllModalVisible: Boolean,
     val deleteModal1Visible: Boolean,
     val choosePeriodModal: ChoosePeriodModalData?,
+    val compactTransactionsModeEnabled: Boolean,
 )

--- a/screen/transactions/src/main/java/com/ivy/transactions/TransactionsViewModel.kt
+++ b/screen/transactions/src/main/java/com/ivy/transactions/TransactionsViewModel.kt
@@ -28,6 +28,7 @@ import com.ivy.data.repository.TagRepository
 import com.ivy.data.repository.TransactionRepository
 import com.ivy.data.repository.mapper.TransactionMapper
 import com.ivy.design.l0_system.RedLight
+import com.ivy.domain.features.Features
 import com.ivy.frp.then
 import com.ivy.legacy.IvyWalletCtx
 import com.ivy.legacy.data.model.TimePeriod
@@ -83,6 +84,7 @@ class TransactionsViewModel @Inject constructor(
     private val sharedPrefs: SharedPrefs,
     private val accountsAct: AccountsAct,
     private val accTrnsAct: AccTrnsAct,
+    private val features: Features,
     private val trnsWithDateDivsAct: LegacyTrnsWithDateDivsAct,
     private val baseCurrencyAct: BaseCurrencyAct,
     private val calcAccBalanceAct: CalcAccBalanceAct,
@@ -161,7 +163,8 @@ class TransactionsViewModel @Inject constructor(
             enableDeletionButton = getEnableDeletionButton(),
             skipAllModalVisible = getSkipAllModalVisible(),
             deleteModal1Visible = getDeleteModal1Visible(),
-            choosePeriodModal = getChoosePeriodModal()
+            choosePeriodModal = getChoosePeriodModal(),
+            compactTransactionsModeEnabled = getCompactTransactionsMode()
         )
     }
 
@@ -293,6 +296,11 @@ class TransactionsViewModel @Inject constructor(
     @Composable
     private fun getChoosePeriodModal(): ChoosePeriodModalData? {
         return choosePeriodModal.value
+    }
+
+    @Composable
+    private fun getCompactTransactionsMode(): Boolean {
+        return features.compactTransactionsMode.asEnabledState()
     }
 
     override fun onEvent(event: TransactionsEvent) {

--- a/shared/domain/src/main/java/com/ivy/domain/features/FeatureGroup.kt
+++ b/shared/domain/src/main/java/com/ivy/domain/features/FeatureGroup.kt
@@ -1,5 +1,5 @@
 package com.ivy.domain.features
 
 enum class FeatureGroup {
-    Category, Account, Other
+    Transactions, Category, Account, Other
 }

--- a/shared/domain/src/main/java/com/ivy/domain/features/Features.kt
+++ b/shared/domain/src/main/java/com/ivy/domain/features/Features.kt
@@ -1,6 +1,7 @@
 package com.ivy.domain.features
 
 interface Features {
+    val compactTransactionsMode: BoolFeature
     val sortCategoriesAscending: BoolFeature
     val compactAccountsMode: BoolFeature
     val compactCategoriesMode: BoolFeature

--- a/shared/domain/src/main/java/com/ivy/domain/features/IvyFeatures.kt
+++ b/shared/domain/src/main/java/com/ivy/domain/features/IvyFeatures.kt
@@ -6,6 +6,13 @@ import javax.inject.Singleton
 @Singleton
 class IvyFeatures @Inject constructor() : Features {
 
+    override val compactTransactionsMode = BoolFeature(
+        key = "compact_transactions_ui",
+        group = FeatureGroup.Transactions,
+        name = "Compact transaction cards",
+        description = "Simplified design of the transaction card"
+    )
+
     override val sortCategoriesAscending = BoolFeature(
         key = "sort_categories_ascending",
         group = FeatureGroup.Category,
@@ -69,6 +76,7 @@ class IvyFeatures @Inject constructor() : Features {
 
     override val allFeatures: List<BoolFeature>
         get() = listOf(
+            compactTransactionsMode,
             sortCategoriesAscending,
             compactAccountsMode,
             compactCategoriesMode,

--- a/shared/ui/core/src/main/res/values-gl/strings.xml
+++ b/shared/ui/core/src/main/res/values-gl/strings.xml
@@ -493,6 +493,8 @@
     <string name="warning_import_csv_file">"\n!!!⚠️ADVERTENCIA: A importación pode duplicar as transaccións!!!\nAs transaccións duplicadas non se poden eliminar facilmente e terás que eliminalas manualmente unha a unha! \nMotivo: Non podemos analizar os identificadores de transacción porque Ivy Wallet só funciona con UUID e outras aplicacións non.\nSe estás comezando de cero, non te preocupes - ignora amablemente esta mensaxe."</string>
     <string name="select_tags">Seleccionar etiquetas</string>
     <string name="bill_paid">A túa factura de %1$s %2$s foi pagada</string>
+<!--    TODO - Edit this 'income_received' accordingly-->
+    <string name="income_received">A túa factura de %1$s %2$s foi pagada</string>
     <string name="language">Lingua</string>
     <string name="advanced_features">Funcionalidades avanzadas</string>
 </resources>

--- a/shared/ui/core/src/main/res/values-zh-rTW/strings.xml
+++ b/shared/ui/core/src/main/res/values-zh-rTW/strings.xml
@@ -493,6 +493,8 @@
     <string name="warning_import_csv_file">"\n!!!⚠️警告: 導入可能會重複交易!!!\n重複的交易無法輕易刪除，您需要手動刪除其中的每一項!\n原因: 我們無法解析交易 ID，因為 Ivy wallet 僅適用於 UUID，而其他應用程式則不能。\n如果您剛開始，不用擔心 -請忽略此訊息。"</string>
     <string name="select_tags">選擇標籤</string>
     <string name="bill_paid">您的 %1$s %2$s 帳單已支付</string>
+    <!--    TODO - Edit this 'income_received' accordingly-->
+    <string name="income_received">您的 %1$s %2$s 帳單已支付</string>
     <string name="language">語言</string>
     <string name="advanced_features">進階功能</string>
 </resources>

--- a/shared/ui/core/src/main/res/values/strings.xml
+++ b/shared/ui/core/src/main/res/values/strings.xml
@@ -493,6 +493,7 @@
     <string name="warning_import_csv_file">"\n!!!⚠️ WARNING: Importing may create duplicate transactions!!!\nPlease note that duplicate transactions cannot be easily removed and will need to be deleted individually.\nReason: We cannot parse transaction IDs because Ivy Wallet uses UUIDs exclusively, while other apps do not.\nIf you\'re starting fresh, you can safely ignore this message."</string>
     <string name="select_tags">Select Tags</string>
     <string name="bill_paid">Your bill for %1$s %2$s has been paid</string>
+    <string name="income_received">Income for %1$s %2$s received</string>
     <string name="language">Language</string>
     <string name="advanced_features">Advanced features</string>
 </resources>

--- a/temp/legacy-code/src/main/java/com/ivy/legacy/legacy/ui/theme/wallet/AmountCurrency.kt
+++ b/temp/legacy-code/src/main/java/com/ivy/legacy/legacy/ui/theme/wallet/AmountCurrency.kt
@@ -1,17 +1,24 @@
 package com.ivy.wallet.ui.theme.wallet
 
 import android.annotation.SuppressLint
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.ivy.design.l0_system.UI
 import com.ivy.design.l0_system.style
 import com.ivy.legacy.utils.format
@@ -99,6 +106,94 @@ fun AmountCurrencyB1(
             color = textColor
         )
     )
+}
+
+@SuppressLint(
+    "ComposeContentEmitterReturningValues",
+    "ComposeMultipleContentEmitters",
+    "ComposeModifierMissing"
+)
+@Composable
+fun RowScope.AmountCurrencyB1RowScope(
+    amount: Double,
+    currency: String,
+    modifier: Modifier = Modifier,
+    amountFontWeight: FontWeight = FontWeight.Bold,
+    textColor: Color = UI.colors.pureInverse,
+    shortenBigNumbers: Boolean = false
+) {
+    val configuration = LocalConfiguration.current
+    val screenWidth = remember { configuration.screenWidthDp.dp }
+
+    val shortAmount = shortenBigNumbers && shouldShortAmount(amount)
+    val text = if (shortAmount) shortenAmount(amount) else amount.format(currency)
+
+    /**
+     * Hacky way -> Needs to be worked upon in future.
+     * Added these `widthMin` modifiers as safeguard for cases when
+     * the amount text or the currency text is too large and it
+     * overflows from the screen potentially making either the amount or
+     * the currency hidden
+     * */
+    Row(modifier = modifier) {
+        Text(
+            modifier = Modifier.testTag("amount_currency_b1")
+                .widthIn(max = screenWidth.times(0.5f)),
+            text = text,
+            style = UI.typo.nB1.style(
+                fontWeight = amountFontWeight,
+                color = textColor
+            )
+        )
+        Spacer(modifier = Modifier.width(4.dp))
+        Text(
+            text = currency,
+            style = UI.typo.nB1.style(
+                fontWeight = FontWeight.Normal,
+                color = textColor
+            ),
+            modifier = Modifier.widthIn(max = screenWidth.times(0.5f))
+        )
+    }
+}
+
+@SuppressLint(
+    "ComposeContentEmitterReturningValues",
+    "ComposeMultipleContentEmitters",
+    "ComposeModifierMissing"
+)
+@Composable
+fun AmountCurrencyB1Compact(
+    amount: Double,
+    currency: String,
+    modifier: Modifier = Modifier,
+    amountFontWeight: FontWeight = FontWeight.Bold,
+    textColor: Color = UI.colors.pureInverse,
+    shortenBigNumbers: Boolean = true
+) {
+    val shortAmount = shortenBigNumbers && shouldShortAmount(amount)
+    val text = if (shortAmount) shortenAmount(amount) else amount.format(currency)
+    Column(modifier) {
+        Text(
+            modifier = Modifier.testTag("amount_currency_b1"),
+            text = text,
+            style = UI.typo.nB1.style(
+                fontWeight = amountFontWeight,
+                color = textColor,
+            ).copy(
+                fontSize = 18.sp
+            )
+        )
+        Text(
+            text = currency,
+            style = UI.typo.nB2.style(
+                fontWeight = FontWeight.Normal,
+                color = textColor
+            ),
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
 }
 
 @SuppressLint(

--- a/temp/legacy-code/src/main/java/com/ivy/legacy/ui/component/transaction/TransactionCard.kt
+++ b/temp/legacy-code/src/main/java/com/ivy/legacy/ui/component/transaction/TransactionCard.kt
@@ -1,6 +1,7 @@
 package com.ivy.legacy.ui.component.transaction
 
 import androidx.annotation.DrawableRes
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -15,23 +16,34 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.unit.times
 import com.ivy.base.legacy.LegacyTag
 import com.ivy.base.legacy.Transaction
 import com.ivy.base.model.TransactionType
@@ -52,9 +64,12 @@ import com.ivy.legacy.IvyWalletPreview
 import com.ivy.legacy.data.AppBaseData
 import com.ivy.legacy.datamodel.Account
 import com.ivy.legacy.utils.capitalizeLocal
+import com.ivy.legacy.utils.clickableNoIndication
 import com.ivy.legacy.utils.dateNowUTC
 import com.ivy.legacy.utils.format
 import com.ivy.legacy.utils.isNotNullOrBlank
+import com.ivy.legacy.utils.rememberInteractionSource
+import com.ivy.legacy.utils.springBounce
 import com.ivy.legacy.utils.timeNowUTC
 import com.ivy.navigation.Navigation
 import com.ivy.navigation.TransactionsScreen
@@ -82,9 +97,11 @@ import com.ivy.wallet.ui.theme.components.IvyIcon
 import com.ivy.wallet.ui.theme.findContrastTextColor
 import com.ivy.wallet.ui.theme.gradientExpenses
 import com.ivy.wallet.ui.theme.toComposeColor
-import com.ivy.wallet.ui.theme.wallet.AmountCurrencyB1
+import com.ivy.wallet.ui.theme.wallet.AmountCurrencyB1Compact
+import com.ivy.wallet.ui.theme.wallet.AmountCurrencyB1RowScope
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
+import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneOffset
 import java.util.UUID
@@ -99,10 +116,17 @@ fun TransactionCard(
 
     onPayOrGet: (Transaction) -> Unit,
     modifier: Modifier = Modifier,
+    compactModeEnabled: Boolean = true, // TODO(Pass this down from viewmodels to ui to this component)
     onSkipTransaction: (Transaction) -> Unit = {},
 
     onClick: (Transaction) -> Unit,
 ) {
+    /**
+     * State for tracking whether the buttons are expanded
+     * When the skip and pay/get buttons are to be shown in compact mode
+     * */
+    var expanded by rememberSaveable { mutableStateOf(false) }
+
     Column(
         modifier = modifier
             .fillMaxWidth()
@@ -126,148 +150,66 @@ fun TransactionCard(
             baseData.accounts.find { it.id == transaction.toAccountId }?.currency
                 ?: baseData.baseCurrency
 
-        Spacer(Modifier.height(20.dp))
-
-        TransactionHeaderRow(
-            transaction = transaction,
-            categories = baseData.categories,
-            accounts = baseData.accounts,
+        Spacer(
+            Modifier.height(
+                if (compactModeEnabled) 4.dp else 20.dp
+            )
         )
 
-        if (transaction.dueDate != null) {
-            Spacer(Modifier.height(12.dp))
+        if (!compactModeEnabled) {
 
-            val timeFormatter = LocalTimeFormatter.current
-            val timeProvider = LocalTimeProvider.current
-            Text(
-                modifier = Modifier.padding(horizontal = 24.dp),
-                text = stringResource(
-                    R.string.due_on,
-                    with(timeFormatter) {
-                        transaction.dueDate!!.formatLocal(
-                            TimeFormatter.Style.DateOnly(
-                                includeWeekDay = true
-                            )
-                        )
-                    }
-                ).uppercase(),
-                style = UI.typo.nC.style(
-                    color = if (transaction.dueDate!!.isAfter(timeProvider.utcNow())) {
-                        Orange
-                    } else {
-                        UI.colors.gray
-                    },
-                    fontWeight = FontWeight.Bold
-                )
+            TransactionHeaderRow(
+                transaction = transaction,
+                categories = baseData.categories,
+                accounts = baseData.accounts,
             )
+            DueDate(transaction, false)
+            Title(
+                title = transaction.title,
+                dueDate = transaction.dueDate,
+                compactModeEnabled = false
+            )
+            Description(transaction)
         }
 
-        if (transaction.title.isNotNullOrBlank()) {
-            Spacer(
-                Modifier.height(
-                    if (transaction.dueDate != null) 8.dp else 12.dp
-                )
-            )
-
-            Text(
-                modifier = Modifier.padding(horizontal = 24.dp),
-                text = transaction.title!!,
-                style = UI.typo.b1.style(
-                    fontWeight = FontWeight.ExtraBold,
-                    color = UI.colors.pureInverse
-                )
-            )
-        }
-
-        val description = getTransactionDescription(transaction)
-        if (!description.isNullOrBlank()) {
-            Spacer(Modifier.height(if (transaction.title.isNotNullOrBlank()) 4.dp else 8.dp))
-            Text(
-                text = description,
-                modifier = Modifier.padding(horizontal = 24.dp),
-                style = UI.typo.nC.style(
-                    color = UI.colors.gray,
-                    fontWeight = FontWeight.Bold
-                ),
-                maxLines = 3,
-                overflow = TextOverflow.Ellipsis
-            )
-        }
-
-        if (transaction.dueDate != null) {
+        if (transaction.dueDate != null || compactModeEnabled) {
             Spacer(Modifier.height(12.dp))
         } else {
             Spacer(Modifier.height(16.dp))
         }
 
-        TypeAmountCurrency(
-            transactionType = transaction.type,
-            dueDate = with(LocalTimeConverter.current) {
-                transaction.dueDate?.toLocalDateTime()
-            },
-            currency = transactionCurrency,
-            amount = transaction.amount.toDouble()
+        TitleAndTypeAmountCurrencyRow(
+            transaction = transaction,
+            transactionCurrency = transactionCurrency,
+            toAccountCurrency = toAccountCurrency,
+            compactModeEnabled = compactModeEnabled
         )
 
-        if (transaction.type == TransactionType.TRANSFER && toAccountCurrency != transactionCurrency) {
-            Text(
-                modifier = Modifier.padding(start = 68.dp),
-                text = "${
-                    transaction.toAmount.toDouble()
-                        .format(IvyCurrency.getDecimalPlaces(toAccountCurrency))
-                } $toAccountCurrency",
-                style = UI.typo.nB2.style(
-                    color = Gray,
-                    fontWeight = FontWeight.Normal
-                )
+        if (!compactModeEnabled) {
+            PayOrGetButtons(
+                transaction = transaction,
+                onPayOrGet = onPayOrGet,
+                onSkipTransaction = onSkipTransaction,
+                compactModeEnabled = false
+            )
+            if (transaction.tags.isNotEmpty()) {
+                TransactionTags(transaction.tags)
+            }
+        } else {
+            PayOrGetButtonsExpandable(
+                expanded = expanded,
+                transaction = transaction,
+                onPayOrGet = onPayOrGet,
+                onSkipTransaction = onSkipTransaction,
+                toggleExpanded = { expanded = expanded.not() }
             )
         }
 
-        if (transaction.dueDate != null && transaction.dateTime == null) {
-            // Pay/Get button
-            Spacer(Modifier.height(16.dp))
-
-            val isExpense = transaction.type == TransactionType.EXPENSE
-            Row {
-                IvyButton(
-                    modifier = Modifier
-                        .weight(1f)
-                        .padding(start = 24.dp),
-                    text = stringResource(R.string.skip),
-                    wrapContentMode = false,
-                    backgroundGradient = Gradient.solid(UI.colors.pure),
-                    textStyle = UI.typo.b2.style(
-                        color = UI.colors.pureInverse,
-                        fontWeight = FontWeight.Bold
-                    )
-                ) {
-                    onSkipTransaction(transaction)
-                }
-
-                Spacer(Modifier.width(8.dp))
-
-                IvyButton(
-                    modifier = Modifier
-                        .weight(1f)
-                        .padding(end = 24.dp),
-                    text = if (isExpense) stringResource(R.string.pay) else stringResource(R.string.get),
-                    wrapContentMode = false,
-                    backgroundGradient = if (isExpense) gradientExpenses() else GradientGreen,
-                    textStyle = UI.typo.b2.style(
-                        color = if (isExpense) UI.colors.pure else White,
-                        fontWeight = FontWeight.Bold
-                    )
-                ) {
-                    onPayOrGet(transaction)
-                }
-            }
-        }
-
-        if (transaction.tags.isNotEmpty()) {
-            TransactionTags(transaction.tags)
-        }
-
-        Spacer(Modifier.height(20.dp))
+        Spacer(
+            Modifier.height(
+                if (compactModeEnabled) 16.dp else 20.dp
+            )
+        )
     }
 }
 
@@ -397,6 +339,7 @@ private fun getTransactionDescription(transaction: Transaction): String? {
                 transaction.dueDate == null &&
                 paidFor != null -> {
             stringResource(
+                // Todo(Due transaction description: This needs to be set depending on whether it is income or expense)
                 R.string.bill_paid,
                 paidFor.month.name.lowercase().capitalizeLocal(),
                 paidFor.year.toString()
@@ -517,69 +460,71 @@ fun TypeAmountCurrency(
     dueDate: LocalDateTime?,
     currency: String,
     amount: Double,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    compactModeEnabled: Boolean = false,
 ) {
+    val configuration = LocalConfiguration.current
+    val screenWidth = remember { configuration.screenWidthDp.dp }
+
+    val style = when (transactionType) {
+        TransactionType.INCOME -> {
+            AmountTypeStyle(
+                icon = R.drawable.ic_income,
+                gradient = GradientGreen,
+                iconTint = White,
+                textColor = Green
+            )
+        }
+
+        TransactionType.EXPENSE -> {
+            when {
+                dueDate != null && dueDate.isAfter(timeNowUTC()) -> {
+                    // Upcoming Expense
+                    AmountTypeStyle(
+                        icon = R.drawable.ic_expense,
+                        gradient = GradientOrangeRevert,
+                        iconTint = White,
+                        textColor = Orange
+                    )
+                }
+
+                dueDate != null && dueDate.isBefore(dateNowUTC().atStartOfDay()) -> {
+                    // Overdue Expense
+                    AmountTypeStyle(
+                        icon = R.drawable.ic_overdue,
+                        gradient = GradientRed,
+                        iconTint = White,
+                        textColor = Red
+                    )
+                }
+
+                else -> {
+                    // Normal Expense
+                    AmountTypeStyle(
+                        icon = R.drawable.ic_expense,
+                        gradient = Gradient.black(),
+                        iconTint = White,
+                        textColor = UI.colors.pureInverse
+                    )
+                }
+            }
+        }
+
+        TransactionType.TRANSFER -> {
+            // Transfer
+            AmountTypeStyle(
+                icon = R.drawable.ic_transfer,
+                gradient = GradientIvy,
+                iconTint = White,
+                textColor = Ivy
+            )
+        }
+    }
+
     Row(
         modifier = modifier.testTag("type_amount_currency"),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Spacer(Modifier.width(24.dp))
-
-        val style = when (transactionType) {
-            TransactionType.INCOME -> {
-                AmountTypeStyle(
-                    icon = R.drawable.ic_income,
-                    gradient = GradientGreen,
-                    iconTint = White,
-                    textColor = Green
-                )
-            }
-
-            TransactionType.EXPENSE -> {
-                when {
-                    dueDate != null && dueDate.isAfter(timeNowUTC()) -> {
-                        // Upcoming Expense
-                        AmountTypeStyle(
-                            icon = R.drawable.ic_expense,
-                            gradient = GradientOrangeRevert,
-                            iconTint = White,
-                            textColor = Orange
-                        )
-                    }
-
-                    dueDate != null && dueDate.isBefore(dateNowUTC().atStartOfDay()) -> {
-                        // Overdue Expense
-                        AmountTypeStyle(
-                            icon = R.drawable.ic_overdue,
-                            gradient = GradientRed,
-                            iconTint = White,
-                            textColor = Red
-                        )
-                    }
-
-                    else -> {
-                        // Normal Expense
-                        AmountTypeStyle(
-                            icon = R.drawable.ic_expense,
-                            gradient = Gradient.black(),
-                            iconTint = White,
-                            textColor = UI.colors.pureInverse
-                        )
-                    }
-                }
-            }
-
-            TransactionType.TRANSFER -> {
-                // Transfer
-                AmountTypeStyle(
-                    icon = R.drawable.ic_transfer,
-                    gradient = GradientIvy,
-                    iconTint = White,
-                    textColor = Ivy
-                )
-            }
-        }
-
         IvyIcon(
             modifier = Modifier
                 .background(style.gradient.asHorizontalBrush(), CircleShape),
@@ -587,15 +532,297 @@ fun TypeAmountCurrency(
             tint = style.iconTint
         )
 
-        Spacer(Modifier.width(12.dp))
-
-        AmountCurrencyB1(
-            amount = amount,
-            currency = currency,
-            textColor = style.textColor
+        Spacer(
+            Modifier.width(
+                if (compactModeEnabled) 8.dp else 12.dp
+            )
         )
 
-        Spacer(Modifier.width(24.dp))
+        /**
+         * Hacky way -> Needs to be worked upon in future.
+         * Added these `widthMin` modifiers as safeguard for cases when
+         * the amount currency row i.e. the amount or the currency is too
+         * large and overflows from the screen potentially making anything
+         * that follows in this row to be hidden (title in this case)
+         * This is for cases when user enters a manual currency that is too long
+         * or when user enters the max value of amount (Double.MAX_VALUE).
+         * */
+        if (!compactModeEnabled) {
+            AmountCurrencyB1RowScope(
+                amount = amount,
+                currency = currency,
+                textColor = style.textColor,
+                modifier = Modifier.widthIn(max = 0.7f * screenWidth)
+            )
+        } else AmountCurrencyB1Compact(
+            amount = amount,
+            currency = currency,
+            textColor = style.textColor,
+            modifier = Modifier.widthIn(max = 0.5f * screenWidth)
+        )
+    }
+}
+
+@Composable
+private fun Title(
+    title: String?,
+    dueDate: Instant?,
+    compactModeEnabled: Boolean,
+    modifier: Modifier = Modifier
+) {
+    if (title.isNotNullOrBlank()) {
+        Spacer(
+            Modifier.height(
+                if (dueDate != null) 8.dp else 12.dp
+            )
+        )
+
+        Text(
+            modifier = modifier.padding(horizontal = 24.dp),
+            text = title!!,
+            style = UI.typo.b1.style(
+                fontWeight = FontWeight.ExtraBold,
+                color = UI.colors.pureInverse
+            ).copy(
+                fontSize = if (compactModeEnabled) 18.sp else 20.sp,
+                textAlign = if (compactModeEnabled) TextAlign.End else TextAlign.Start,
+            ),
+            // Apply max lines and ellipsis in compact mode
+            maxLines = if (compactModeEnabled) 2 else Int.MAX_VALUE,
+            overflow = if (compactModeEnabled) TextOverflow.Ellipsis else TextOverflow.Clip,
+        )
+    }
+}
+
+@Composable
+private fun Description(
+    transaction: Transaction
+) {
+    val description = getTransactionDescription(transaction)
+    if (!description.isNullOrBlank()) {
+        Spacer(Modifier.height(if (transaction.title.isNotNullOrBlank()) 4.dp else 8.dp))
+        Text(
+            text = description,
+            modifier = Modifier.padding(horizontal = 24.dp),
+            style = UI.typo.nC.style(
+                color = UI.colors.gray,
+                fontWeight = FontWeight.Bold
+            ),
+            maxLines = 3,
+            overflow = TextOverflow.Ellipsis
+        )
+    }
+}
+
+@Composable
+private fun DueDate(
+    transaction: Transaction,
+    compactModeEnabled: Boolean
+) {
+    if (transaction.dueDate != null) {
+        Spacer(
+            Modifier.height(
+                if (compactModeEnabled) 12.dp else 12.dp
+            )
+        )
+
+        val timeFormatter = LocalTimeFormatter.current
+        val timeProvider = LocalTimeProvider.current
+        Text(
+            modifier = Modifier.padding(horizontal = 24.dp),
+            text = stringResource(
+                R.string.due_on,
+                with(timeFormatter) {
+                    transaction.dueDate!!.formatLocal(
+                        TimeFormatter.Style.DateOnly(
+                            includeWeekDay = true
+                        )
+                    )
+                }
+            ).uppercase(),
+            style = UI.typo.nC.style(
+                color = if (transaction.dueDate!!.isAfter(timeProvider.utcNow())) {
+                    Orange
+                } else {
+                    UI.colors.gray
+                },
+                fontWeight = FontWeight.Bold
+            )
+        )
+    }
+}
+
+@Composable
+private fun TitleAndTypeAmountCurrencyRow(
+    transaction: Transaction,
+    transactionCurrency: String,
+    toAccountCurrency: String,
+    compactModeEnabled: Boolean
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(
+                start = 24.dp,
+                end = if (compactModeEnabled) 2.dp else 24.dp
+            ),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        // Transaction type icon and amount
+        TypeAmountCurrency(
+            transactionType = transaction.type,
+            dueDate = with(LocalTimeConverter.current) {
+                transaction.dueDate?.toLocalDateTime()
+            },
+            currency = transactionCurrency,
+            amount = transaction.amount.toDouble(),
+            compactModeEnabled = compactModeEnabled,
+        )
+
+        // Title
+        if (compactModeEnabled) {
+            Title(
+                title = transaction.title,
+                dueDate = transaction.dueDate,
+                compactModeEnabled = true,
+            )
+        }
+    }
+
+    // Optional different currency conversion text
+    if (transaction.type == TransactionType.TRANSFER && toAccountCurrency != transactionCurrency) {
+        Text(
+            modifier = Modifier.padding(
+                start = if (compactModeEnabled) 64.dp else 68.dp
+            ),
+            text = "${
+                transaction.toAmount.toDouble()
+                    .format(IvyCurrency.getDecimalPlaces(toAccountCurrency))
+            } $toAccountCurrency",
+            style = UI.typo.nB2.style(
+                color = Gray,
+                fontWeight = FontWeight.Normal
+            ).copy(
+                fontSize = if (compactModeEnabled) 14.sp else 16.sp
+            )
+        )
+    }
+}
+
+@Composable
+private fun PayOrGetButtons(
+    transaction: Transaction,
+    onPayOrGet: (Transaction) -> Unit,
+    onSkipTransaction: (Transaction) -> Unit,
+    compactModeEnabled: Boolean
+) {
+    // Skip and Pay/Get buttons
+    if (transaction.dueDate != null && transaction.dateTime == null) {
+        Spacer(
+            Modifier.height(
+                if (compactModeEnabled) 12.dp else 16.dp
+            )
+        )
+
+        val isExpense = transaction.type == TransactionType.EXPENSE
+        Row {
+            IvyButton(
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(start = 24.dp),
+                text = stringResource(R.string.skip),
+                wrapContentMode = false,
+                backgroundGradient = Gradient.solid(UI.colors.pure),
+                textStyle = UI.typo.b2.style(
+                    color = UI.colors.pureInverse,
+                    fontWeight = FontWeight.Bold
+                )
+            ) {
+                onSkipTransaction(transaction)
+            }
+
+            Spacer(Modifier.width(8.dp))
+
+            IvyButton(
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(end = 24.dp),
+                text = if (isExpense) stringResource(R.string.pay) else stringResource(R.string.get),
+                wrapContentMode = false,
+                backgroundGradient = if (isExpense) gradientExpenses() else GradientGreen,
+                textStyle = UI.typo.b2.style(
+                    color = if (isExpense) UI.colors.pure else White,
+                    fontWeight = FontWeight.Bold
+                )
+            ) {
+                onPayOrGet(transaction)
+            }
+        }
+    }
+}
+
+// For only when compact mode enabled
+@Composable
+private fun PayOrGetButtonsExpandable(
+    transaction: Transaction,
+    onPayOrGet: (Transaction) -> Unit,
+    onSkipTransaction: (Transaction) -> Unit,
+    expanded: Boolean = false,
+    toggleExpanded: () -> Unit = {},
+) {
+    val canExpand = transaction.dueDate != null && transaction.dateTime == null
+    val interactionSource = rememberInteractionSource()
+    val iconClick = remember {
+        Modifier.clickableNoIndication(interactionSource) {
+            if (canExpand) {
+                toggleExpanded()
+            }
+        }
+    }
+
+    /**
+     * Never gonna happen (just for previews) - as safeguard
+     * if this scenario is ever shown to the user due to some bug
+     * Hacky top padding when the drop down icon is not showing
+     * But the "due on" text is to be shown
+     * */
+    if (!canExpand && transaction.dueDate != null) {
+        Spacer(Modifier.height(8.dp))
+    }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        val expandIconRotation by animateFloatAsState(
+            targetValue = if (expanded && canExpand) -180f else 0f,
+            animationSpec = springBounce()
+        )
+
+        DueDate(transaction, true)
+
+        Spacer(Modifier.weight(1f))
+
+        if (canExpand) {
+            IvyIcon(
+                modifier = Modifier
+                    .rotate(expandIconRotation)
+                    .then(iconClick),
+                icon = R.drawable.ic_expandarrow
+            )
+            Spacer(Modifier.width(24.dp))
+        }
+    }
+
+    if (expanded) {
+        PayOrGetButtons(
+            transaction = transaction,
+            onPayOrGet = onPayOrGet,
+            onSkipTransaction = onSkipTransaction,
+            compactModeEnabled = true
+        )
     }
 }
 
@@ -636,6 +863,7 @@ private fun PreviewUpcomingExpense() {
                         dateTime = null,
                         type = TransactionType.EXPENSE,
                     ),
+                    compactModeEnabled = false,
                     onPayOrGet = {},
                 ) {
                 }
@@ -672,8 +900,10 @@ private fun PreviewUpcomingExpenseBadgeSecondRow() {
                         amount = 250.75.toBigDecimal(),
                         dueDate = timeNowUTC().plusDays(5).toInstant(ZoneOffset.UTC),
                         dateTime = null,
+                        description = "This is a sample description",
                         type = TransactionType.EXPENSE,
                     ),
+                    compactModeEnabled = false,
                     onPayOrGet = {},
                 ) {
                 }
@@ -712,6 +942,7 @@ private fun PreviewOverdueExpense() {
                         dateTime = null,
                         type = TransactionType.EXPENSE
                     ),
+                    compactModeEnabled = false,
                     onPayOrGet = {},
                 ) {
                 }
@@ -749,6 +980,7 @@ private fun PreviewNormalExpense() {
                         dateTime = timeNowUTC().toInstant(ZoneOffset.UTC),
                         type = TransactionType.EXPENSE
                     ),
+                    compactModeEnabled = false,
                     onPayOrGet = {},
                 ) {
                 }
@@ -786,6 +1018,7 @@ private fun PreviewIncome() {
                         dateTime = timeNowUTC().toInstant(ZoneOffset.UTC),
                         type = TransactionType.INCOME
                     ),
+                    compactModeEnabled = false,
                     onPayOrGet = {},
                 ) {
                 }
@@ -817,6 +1050,7 @@ private fun PreviewTransfer() {
                         dateTime = timeNowUTC().toInstant(ZoneOffset.UTC),
                         type = TransactionType.TRANSFER
                     ),
+                    compactModeEnabled = false,
                     onPayOrGet = {},
                 ) {
                 }
@@ -854,6 +1088,349 @@ private fun PreviewTransfer_differentCurrency() {
                         dateTime = timeNowUTC().toInstant(ZoneOffset.UTC),
                         type = TransactionType.TRANSFER
                     ),
+                    compactModeEnabled = true,
+                    onPayOrGet = {},
+                ) {
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewUpcomingIncome() {
+    IvyWalletPreview {
+        LazyColumn(Modifier.fillMaxSize()) {
+            val cash = Account(name = "DSK Bank", color = Green.toArgb())
+            val category = Category(
+                name = NotBlankTrimmedString.unsafe("Salary"),
+                color = ColorInt(GreenDark.toArgb()),
+                icon = null,
+                id = CategoryId(UUID.randomUUID()),
+                orderNum = 0.0,
+            )
+
+            item {
+                TransactionCard(
+                    baseData = AppBaseData(
+                        baseCurrency = "BGN",
+                        categories = persistentListOf(category),
+                        accounts = persistentListOf(cash)
+                    ),
+                    transaction = Transaction(
+                        accountId = cash.id,
+                        title = "Qredo Salary May",
+                        categoryId = category.id.value,
+                        amount = 8049.70.toBigDecimal(),
+                        dueDate = timeNowUTC().plusDays(5).toInstant(ZoneOffset.UTC),
+                        dateTime = null,
+                        type = TransactionType.INCOME
+                    ),
+                    compactModeEnabled = false,
+                    onPayOrGet = {},
+                ) {
+                }
+            }
+        }
+    }
+}
+@Preview
+@Composable
+private fun PreviewCompactUpcomingExpense() {
+    IvyWalletPreview {
+        LazyColumn(Modifier.fillMaxSize()) {
+            val cash = Account(name = "Cash", Green.toArgb())
+            val food = Category(
+                name = NotBlankTrimmedString.unsafe("Food"),
+                color = ColorInt(Blue.toArgb()),
+                icon = null,
+                id = CategoryId(UUID.randomUUID()),
+                orderNum = 0.0,
+            )
+
+            item {
+                TransactionCard(
+                    baseData = AppBaseData(
+                        baseCurrency = "BGN",
+                        categories = persistentListOf(food),
+                        accounts = persistentListOf(cash)
+                    ),
+                    transaction = Transaction(
+                        accountId = cash.id,
+                        title = "Lidl pazar",
+                        categoryId = food.id.value,
+                        amount = 250.75.toBigDecimal(),
+                        dueDate = timeNowUTC().plusDays(5).toInstant(ZoneOffset.UTC),
+                        dateTime = null,
+                        type = TransactionType.EXPENSE,
+                    ),
+                    compactModeEnabled = true,
+                    onPayOrGet = {},
+                ) {
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewCompactUpcomingExpenseBadgeSecondRow() {
+    IvyWalletPreview {
+        LazyColumn(Modifier.fillMaxSize()) {
+            val cash = Account(name = "Cash", Green.toArgb())
+            val food = Category(
+                name = NotBlankTrimmedString.unsafe("Food-Travel-Entertaiment-Food"),
+                color = ColorInt(Blue.toArgb()),
+                icon = null,
+                id = CategoryId(UUID.randomUUID()),
+                orderNum = 0.0,
+            )
+
+            item {
+                TransactionCard(
+                    baseData = AppBaseData(
+                        baseCurrency = "BGN",
+                        categories = persistentListOf(food),
+                        accounts = persistentListOf(cash)
+                    ),
+                    transaction = Transaction(
+                        accountId = cash.id,
+                        title = "Lidl pazar",
+                        categoryId = food.id.value,
+                        amount = 250.75.toBigDecimal(),
+                        dueDate = timeNowUTC().plusDays(5).toInstant(ZoneOffset.UTC),
+                        dateTime = null,
+                        description = "This is a sample description",
+                        type = TransactionType.EXPENSE,
+                    ),
+                    compactModeEnabled = true,
+                    onPayOrGet = {},
+                ) {
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewCompactOverdueExpense() {
+    IvyWalletPreview {
+        LazyColumn(Modifier.fillMaxSize()) {
+            val cash = Account(name = "Cash", color = Green.toArgb())
+            val food = Category(
+                name = NotBlankTrimmedString.unsafe("Rent"),
+                color = ColorInt(Green.toArgb()),
+                icon = null,
+                id = CategoryId(UUID.randomUUID()),
+                orderNum = 0.0,
+            )
+
+            item {
+                TransactionCard(
+                    baseData = AppBaseData(
+                        baseCurrency = "BGN",
+                        categories = persistentListOf(food),
+                        accounts = persistentListOf(cash)
+                    ),
+                    transaction = Transaction(
+                        accountId = cash.id,
+                        title = "Rent",
+                        categoryId = food.id.value,
+                        amount = 500.0.toBigDecimal(),
+                        dueDate = timeNowUTC().minusDays(5).toInstant(ZoneOffset.UTC),
+                        dateTime = null,
+                        type = TransactionType.EXPENSE
+                    ),
+                    compactModeEnabled = true,
+                    onPayOrGet = {},
+                ) {
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewCompactNormalExpense() {
+    IvyWalletPreview {
+        LazyColumn(Modifier.fillMaxSize()) {
+            val cash = Account(name = "Cash", color = Green.toArgb())
+            val food = Category(
+                name = NotBlankTrimmedString.unsafe("Bitovi"),
+                color = ColorInt(Orange.toArgb()),
+                icon = IconAsset.unsafe("groceries"),
+                id = CategoryId(UUID.randomUUID()),
+                orderNum = 0.0,
+            )
+
+            item {
+                TransactionCard(
+                    baseData = AppBaseData(
+                        baseCurrency = "BGN",
+                        categories = persistentListOf(food),
+                        accounts = persistentListOf(cash)
+                    ),
+                    transaction = Transaction(
+                        accountId = cash.id,
+                        title = "Близкия магазин",
+                        categoryId = food.id.value,
+                        amount = 32.51.toBigDecimal(),
+                        dateTime = timeNowUTC().toInstant(ZoneOffset.UTC),
+                        type = TransactionType.EXPENSE
+                    ),
+                    compactModeEnabled = true,
+                    onPayOrGet = {},
+                ) {
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewCompactIncome() {
+    IvyWalletPreview {
+        LazyColumn(Modifier.fillMaxSize()) {
+            val cash = Account(name = "DSK Bank", color = Green.toArgb())
+            val category = Category(
+                name = NotBlankTrimmedString.unsafe("Salary"),
+                color = ColorInt(GreenDark.toArgb()),
+                icon = null,
+                id = CategoryId(UUID.randomUUID()),
+                orderNum = 0.0,
+            )
+
+            item {
+                TransactionCard(
+                    baseData = AppBaseData(
+                        baseCurrency = "BGN",
+                        categories = persistentListOf(category),
+                        accounts = persistentListOf(cash)
+                    ),
+                    transaction = Transaction(
+                        accountId = cash.id,
+                        title = "Qredo Salary May",
+                        categoryId = category.id.value,
+                        amount = 8049.70.toBigDecimal(),
+                        dateTime = timeNowUTC().toInstant(ZoneOffset.UTC),
+                        type = TransactionType.INCOME
+                    ),
+                    compactModeEnabled = true,
+                    onPayOrGet = {},
+                ) {
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewCompactTransfer() {
+    IvyWalletPreview {
+        LazyColumn(Modifier.fillMaxSize()) {
+            val acc1 = Account(name = "DSK Bank", color = Green.toArgb(), icon = "bank")
+            val acc2 = Account(name = "Revolut", color = IvyDark.toArgb(), icon = "revolut")
+
+            item {
+                TransactionCard(
+                    baseData = AppBaseData(
+                        baseCurrency = "BGN",
+                        categories = persistentListOf(),
+                        accounts = persistentListOf(acc1, acc2)
+                    ),
+                    transaction = Transaction(
+                        accountId = acc1.id,
+                        toAccountId = acc2.id,
+                        title = "Top-up revolut",
+                        amount = 1000.0.toBigDecimal(),
+                        dateTime = timeNowUTC().toInstant(ZoneOffset.UTC),
+                        type = TransactionType.TRANSFER
+                    ),
+                    compactModeEnabled = true,
+                    onPayOrGet = {},
+                ) {
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewCompactTransfer_differentCurrency() {
+    IvyWalletPreview {
+        LazyColumn(Modifier.fillMaxSize()) {
+            val acc1 = Account(name = "DSK Bank", color = Green.toArgb(), icon = "bank")
+            val acc2 = Account(
+                name = "Revolut",
+                currency = "EUR",
+                color = IvyDark.toArgb(),
+                icon = "revolut"
+            )
+
+            item {
+                TransactionCard(
+                    baseData = AppBaseData(
+                        baseCurrency = "BGN",
+                        categories = persistentListOf(),
+                        accounts = persistentListOf(acc1, acc2)
+                    ),
+                    transaction = Transaction(
+                        accountId = acc1.id,
+                        toAccountId = acc2.id,
+                        title = "Top-up revolut Very long very long very lpng very lpng very lpng very long ",
+                        amount = 5109876543673887654.toBigDecimal(),
+                        toAmount = 5109876543673887654.toBigDecimal(),
+                        dateTime = timeNowUTC().toInstant(ZoneOffset.UTC),
+                        type = TransactionType.TRANSFER
+                    ),
+                    compactModeEnabled = true,
+                    onPayOrGet = {},
+                ) {
+                }
+            }
+        }
+    }
+}
+
+
+@Preview
+@Composable
+private fun PreviewCompactUpcomingIncome() {
+    IvyWalletPreview {
+        LazyColumn(Modifier.fillMaxSize()) {
+            val cash = Account(name = "DSK Bank", color = Green.toArgb())
+            val category = Category(
+                name = NotBlankTrimmedString.unsafe("Salary"),
+                color = ColorInt(GreenDark.toArgb()),
+                icon = null,
+                id = CategoryId(UUID.randomUUID()),
+                orderNum = 0.0,
+            )
+
+            item {
+                TransactionCard(
+                    baseData = AppBaseData(
+                        baseCurrency = "BGN",
+                        categories = persistentListOf(category),
+                        accounts = persistentListOf(cash)
+                    ),
+                    transaction = Transaction(
+                        accountId = cash.id,
+                        title = "Qredo Salary May",
+                        categoryId = category.id.value,
+                        amount = 8049.70.toBigDecimal(),
+                        dueDate = timeNowUTC().plusDays(5).toInstant(ZoneOffset.UTC),
+                        dateTime = null,
+                        type = TransactionType.INCOME
+                    ),
+                    compactModeEnabled = true,
                     onPayOrGet = {},
                 ) {
                 }

--- a/temp/legacy-code/src/main/java/com/ivy/legacy/ui/component/transaction/TransactionCard.kt
+++ b/temp/legacy-code/src/main/java/com/ivy/legacy/ui/component/transaction/TransactionCard.kt
@@ -335,12 +335,19 @@ private fun getTransactionDescription(transaction: Transaction): String? {
         transaction.recurringRuleId != null &&
                 transaction.dueDate == null &&
                 paidFor != null -> {
-            stringResource(
-                // Todo(Due transaction description: This needs to be set depending on whether it is income or expense)
-                R.string.bill_paid,
-                paidFor.month.name.lowercase().capitalizeLocal(),
-                paidFor.year.toString()
-            )
+                    when (transaction.type) {
+                        TransactionType.INCOME -> stringResource(
+                            R.string.income_received,
+                            paidFor.month.name.lowercase().capitalizeLocal(),
+                            paidFor.year.toString()
+                        )
+                        TransactionType.EXPENSE -> stringResource(
+                            R.string.bill_paid,
+                            paidFor.month.name.lowercase().capitalizeLocal(),
+                            paidFor.year.toString()
+                        )
+                        TransactionType.TRANSFER -> null
+                    }
         }
 
         else -> null

--- a/temp/legacy-code/src/main/java/com/ivy/legacy/ui/component/transaction/TransactionCard.kt
+++ b/temp/legacy-code/src/main/java/com/ivy/legacy/ui/component/transaction/TransactionCard.kt
@@ -111,15 +111,12 @@ import java.util.UUID
 @Composable
 fun TransactionCard(
     baseData: AppBaseData,
-
     transaction: Transaction,
-
     onPayOrGet: (Transaction) -> Unit,
-    modifier: Modifier = Modifier,
-    compactModeEnabled: Boolean = true, // TODO(Pass this down from viewmodels to ui to this component)
-    onSkipTransaction: (Transaction) -> Unit = {},
-
+    compactModeEnabled: Boolean,
     onClick: (Transaction) -> Unit,
+    modifier: Modifier = Modifier,
+    onSkipTransaction: (Transaction) -> Unit = {},
 ) {
     /**
      * State for tracking whether the buttons are expanded
@@ -865,8 +862,8 @@ private fun PreviewUpcomingExpense() {
                     ),
                     compactModeEnabled = false,
                     onPayOrGet = {},
-                ) {
-                }
+                    onClick = {},
+                )
             }
         }
     }
@@ -905,8 +902,8 @@ private fun PreviewUpcomingExpenseBadgeSecondRow() {
                     ),
                     compactModeEnabled = false,
                     onPayOrGet = {},
-                ) {
-                }
+                    onClick = {}
+                )
             }
         }
     }
@@ -944,8 +941,8 @@ private fun PreviewOverdueExpense() {
                     ),
                     compactModeEnabled = false,
                     onPayOrGet = {},
-                ) {
-                }
+                    onClick = {}
+                )
             }
         }
     }
@@ -982,8 +979,8 @@ private fun PreviewNormalExpense() {
                     ),
                     compactModeEnabled = false,
                     onPayOrGet = {},
-                ) {
-                }
+                    onClick = {}
+                )
             }
         }
     }
@@ -1020,8 +1017,8 @@ private fun PreviewIncome() {
                     ),
                     compactModeEnabled = false,
                     onPayOrGet = {},
-                ) {
-                }
+                    onClick = {}
+                )
             }
         }
     }
@@ -1052,8 +1049,8 @@ private fun PreviewTransfer() {
                     ),
                     compactModeEnabled = false,
                     onPayOrGet = {},
-                ) {
-                }
+                    onClick = {}
+                )
             }
         }
     }
@@ -1090,8 +1087,8 @@ private fun PreviewTransfer_differentCurrency() {
                     ),
                     compactModeEnabled = true,
                     onPayOrGet = {},
-                ) {
-                }
+                    onClick = {}
+                )
             }
         }
     }
@@ -1129,8 +1126,8 @@ private fun PreviewUpcomingIncome() {
                     ),
                     compactModeEnabled = false,
                     onPayOrGet = {},
-                ) {
-                }
+                    onClick = {}
+                )
             }
         }
     }
@@ -1167,8 +1164,8 @@ private fun PreviewCompactUpcomingExpense() {
                     ),
                     compactModeEnabled = true,
                     onPayOrGet = {},
-                ) {
-                }
+                    onClick = {}
+                )
             }
         }
     }
@@ -1207,8 +1204,8 @@ private fun PreviewCompactUpcomingExpenseBadgeSecondRow() {
                     ),
                     compactModeEnabled = true,
                     onPayOrGet = {},
-                ) {
-                }
+                    onClick = {}
+                )
             }
         }
     }
@@ -1246,8 +1243,8 @@ private fun PreviewCompactOverdueExpense() {
                     ),
                     compactModeEnabled = true,
                     onPayOrGet = {},
-                ) {
-                }
+                    onClick = {}
+                )
             }
         }
     }
@@ -1284,8 +1281,8 @@ private fun PreviewCompactNormalExpense() {
                     ),
                     compactModeEnabled = true,
                     onPayOrGet = {},
-                ) {
-                }
+                    onClick = {}
+                )
             }
         }
     }
@@ -1322,8 +1319,8 @@ private fun PreviewCompactIncome() {
                     ),
                     compactModeEnabled = true,
                     onPayOrGet = {},
-                ) {
-                }
+                    onClick = {}
+                )
             }
         }
     }
@@ -1354,8 +1351,8 @@ private fun PreviewCompactTransfer() {
                     ),
                     compactModeEnabled = true,
                     onPayOrGet = {},
-                ) {
-                }
+                    onClick = {}
+                )
             }
         }
     }
@@ -1392,8 +1389,8 @@ private fun PreviewCompactTransfer_differentCurrency() {
                     ),
                     compactModeEnabled = true,
                     onPayOrGet = {},
-                ) {
-                }
+                    onClick = {}
+                )
             }
         }
     }
@@ -1432,8 +1429,8 @@ private fun PreviewCompactUpcomingIncome() {
                     ),
                     compactModeEnabled = true,
                     onPayOrGet = {},
-                ) {
-                }
+                    onClick = {}
+                )
             }
         }
     }

--- a/temp/legacy-code/src/main/java/com/ivy/legacy/ui/component/transaction/Transactions.kt
+++ b/temp/legacy-code/src/main/java/com/ivy/legacy/ui/component/transaction/Transactions.kt
@@ -227,13 +227,14 @@ private fun LazyListScope.trnItems(
             compactModeEnabled = compactModeEnabled,
             transaction = it,
             onPayOrGet = onPayOrGet,
-            onSkipTransaction = onSkipTransaction
-        ) { trn ->
-            onTransactionClick(
-                nav = nav,
-                transaction = trn
-            )
-        }
+            onSkipTransaction = onSkipTransaction,
+            onClick = { trn ->
+                onTransactionClick(
+                    nav = nav,
+                    transaction = trn
+                )
+            }
+        )
     }
 }
 
@@ -265,13 +266,14 @@ private fun LazyListScope.historySection(
                         baseData = baseData,
                         compactModeEnabled = compactModeEnabled,
                         transaction = it,
-                        onPayOrGet = onPayOrGet
-                    ) { trn ->
-                        onTransactionClick(
-                            nav = nav,
-                            transaction = trn
-                        )
-                    }
+                        onPayOrGet = onPayOrGet,
+                        onClick = { trn ->
+                            onTransactionClick(
+                                nav = nav,
+                                transaction = trn
+                            )
+                        }
+                    )
                 }
 
                 is TransactionHistoryDateDivider -> {

--- a/temp/legacy-code/src/main/java/com/ivy/legacy/ui/component/transaction/Transactions.kt
+++ b/temp/legacy-code/src/main/java/com/ivy/legacy/ui/component/transaction/Transactions.kt
@@ -44,6 +44,7 @@ fun LazyListScope.transactions(
     upcoming: LegacyDueSection?,
     overdue: LegacyDueSection?,
     history: List<TransactionHistoryItem>,
+    compactModeEnabled: Boolean,
 
     emptyStateTitle: String = stringRes(R.string.no_transactions),
     emptyStateText: String,
@@ -60,7 +61,7 @@ fun LazyListScope.transactions(
     upcomingSection(
         baseData = baseData,
         upcoming = upcoming,
-
+        compactModeEnabled = compactModeEnabled,
         onPayOrGet = onPayOrGet,
         onSkipTransaction = onSkipTransaction,
         setExpanded = setUpcomingExpanded
@@ -69,7 +70,7 @@ fun LazyListScope.transactions(
     overdueSection(
         baseData = baseData,
         overdue = overdue,
-
+        compactModeEnabled = compactModeEnabled,
         onPayOrGet = onPayOrGet,
         onSkipTransaction = onSkipTransaction,
         onSkipAllTransactions = onSkipAllTransactions,
@@ -80,7 +81,7 @@ fun LazyListScope.transactions(
         baseData = baseData,
 
         history = history,
-
+        compactModeEnabled = compactModeEnabled,
         dateDividerMarginTop = dateDividerMarginTop,
         onPayOrGet = onPayOrGet
     )
@@ -110,7 +111,7 @@ private fun LazyListScope.upcomingSection(
     baseData: AppBaseData,
 
     upcoming: LegacyDueSection?,
-
+    compactModeEnabled: Boolean,
     onPayOrGet: (Transaction) -> Unit,
     onSkipTransaction: (Transaction) -> Unit,
     setExpanded: (Boolean) -> Unit
@@ -135,7 +136,7 @@ private fun LazyListScope.upcomingSection(
         if (upcoming.expanded) {
             trnItems(
                 baseData = baseData,
-
+                compactModeEnabled = compactModeEnabled,
                 transactions = upcoming.trns,
 
                 onPayOrGet = onPayOrGet,
@@ -149,7 +150,7 @@ private fun LazyListScope.overdueSection(
     baseData: AppBaseData,
 
     overdue: LegacyDueSection?,
-
+    compactModeEnabled: Boolean,
     onPayOrGet: (Transaction) -> Unit,
     onSkipTransaction: (Transaction) -> Unit,
     onSkipAllTransactions: (List<Transaction>) -> Unit,
@@ -200,7 +201,7 @@ private fun LazyListScope.overdueSection(
                 baseData = baseData,
 
                 transactions = overdue.trns,
-
+                compactModeEnabled = compactModeEnabled,
                 onPayOrGet = onPayOrGet,
                 onSkipTransaction = onSkipTransaction
             )
@@ -212,7 +213,7 @@ private fun LazyListScope.trnItems(
     baseData: AppBaseData,
 
     transactions: List<Transaction>,
-
+    compactModeEnabled: Boolean,
     onPayOrGet: (Transaction) -> Unit,
     onSkipTransaction: (Transaction) -> Unit,
 ) {
@@ -223,7 +224,7 @@ private fun LazyListScope.trnItems(
         val nav = navigation()
         TransactionCard(
             baseData = baseData,
-
+            compactModeEnabled = compactModeEnabled,
             transaction = it,
             onPayOrGet = onPayOrGet,
             onSkipTransaction = onSkipTransaction
@@ -240,7 +241,7 @@ private fun LazyListScope.historySection(
     baseData: AppBaseData,
 
     history: List<TransactionHistoryItem>,
-
+    compactModeEnabled: Boolean,
     dateDividerMarginTop: Dp? = null,
 
     onPayOrGet: (Transaction) -> Unit
@@ -262,7 +263,7 @@ private fun LazyListScope.historySection(
 
                     TransactionCard(
                         baseData = baseData,
-
+                        compactModeEnabled = compactModeEnabled,
                         transaction = it,
                         onPayOrGet = onPayOrGet
                     ) { trn ->


### PR DESCRIPTION
## Pull request (PR) checklist

Please check if your pull request fulfills the following requirements:
<!--💡 Tip: Tick checkboxes like this: [x] 💡-->
- [x] I've read the [Contribution Guidelines](https://github.com/Ivy-Apps/ivy-wallet/blob/main/CONTRIBUTING.md) and my PR doesn't break the rules.
- [x] I've read and understand the [Developer Guidelines](https://github.com/Ivy-Apps/ivy-wallet/blob/main/docs/Guidelines.md).
- [x] I confirm that I've run the code locally and everything works as expected.
- [x] My PR includes only the necessary changes to fix the issue (i.e., no unnecessary files or lines of code are changed).
- [x] 🎬 I've attached a **screen recording** of using the new code to the next paragraph (if applicable).

## Screen recording of your changes (if applicable):
https://github.com/user-attachments/assets/7935fc05-dcc8-4958-a140-28d38f683b27

## What's changed?

Describe with a few bullets **what's new:**
- I've refactored the transaction card to support compact mode.
- In the compact mode, the transaction card does not show
  - The account badges 
  - Categories badges
  - Tags row
  - Description
- Hides the due date and the Skip or Pay/Get buttons in a toggleable expand icon
- I have refactored the components into individual reusable composables for better readability and understanding of the file
- The `TypeAmountCurrency` in the non-compact card is also now `TitleTypeAmountCurrencyRow` just without showing the title
- Have handled cases when the user might enter huge currency or huge amount. 
- Additionally, I have introduced a new string value for the case when the recurring transaction is `paidFor` and is of `INCOME` type

| Before                                                                                                     | After                                                                                                      |
|:----------------------------------------------------------------------------------------------------------:|:----------------------------------------------------------------------------------------------------------:|
| [Old cards video](https://github.com/user-attachments/assets/e2ae0fb3-747a-4402-9d96-dcc4f52c0175)          | [Compact cards video](https://github.com/user-attachments/assets/7935fc05-dcc8-4958-a140-28d38f683b27)       |
| ![Old description](https://github.com/user-attachments/assets/fb0d2cba-46f7-43b3-8cc7-4edbed4b6214)        | ![Updated description](https://github.com/user-attachments/assets/4af06777-4653-4d05-af62-a8af23f93839)     |

## Risk factors

**What may go wrong if we merge your PR?**
- The paparazzi screenshot for the :screen:transactions was breaking when the `compactModeEnabled` was set to `true`
- I haven't changed any functionality just the UI so logic shouldn't break.
- The new introduced string value `income_received` needs to be edited for the two languages (Have added Todo comments)

**In what cases won't your code work?**
- Should work since its a simple `Bool Feature`

## Does this PR close any GitHub issues? (do not delete)

- Closes #3498

<!--❗For example: - Closes #123 ❗-->
<!--⚠️ If done correctly, you'll see the issue title linked on the PR preview. ⚠️-->
<!--💡 Tip: Multiple issues:
- Closes #{ISSUE_NUMBER_1}, closes #{ISSUE_NUMBER_2}, closes #{ISSUE_NUMBER_3}
-->
<!-- If the PR doesn't close any GitHub issues, type "Closes N/A" to pass the CI check. -->

## Troubleshooting GitHub Actions (CI) failures ❌
Pull request checks failing? Read our [CI Troubleshooting guide](https://github.com/Ivy-Apps/ivy-wallet/blob/main/docs/CI-Troubleshooting.md).